### PR TITLE
Feat: Mission 도메인 내 팀 표준 규격 및 BaseEntity 적용 및 Mission Exception 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 
     // H2 메모리 데이터베이스 (테스트용)
     runtimeOnly 'com.h2database:h2'
+
+    // PostgreSQL 드라이버
+    runtimeOnly 'org.postgresql:postgresql'
 }
 
 // 6. 의존성 관리 (BOM): Spring AI와 관련된 수많은 하위 라이브러리들의 버전을 1.1.3으로 일관되게 맞춰주어 버전 충돌을 방지합니다.

--- a/src/main/java/me/sogom/bridge/domain/member/entity/Children.java
+++ b/src/main/java/me/sogom/bridge/domain/member/entity/Children.java
@@ -4,14 +4,13 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
+import me.sogom.bridge.domain.common.BaseEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "children")
-public class Children {
+public class Children extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "children_id")
     private Long id;
@@ -27,7 +26,4 @@ public class Children {
 
     @Column(length = 6)
     private String code; // 자녀 연동 코드
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
@@ -3,8 +3,9 @@ package me.sogom.bridge.domain.mission.controller;
 import lombok.RequiredArgsConstructor;
 import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
 import me.sogom.bridge.domain.mission.service.MissionVerificationAiService;
+import me.sogom.bridge.global.apiPayload.ApiResponse;
+import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -21,12 +22,12 @@ public class MissionController {
     private final MissionVerificationAiService aiService;
 
     @PostMapping(value = "/verify-test", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<AiVerificationResponse> testVerification(
+    public ApiResponse<AiVerificationResponse> testVerification( //return type 변경
             @RequestParam("image") MultipartFile image,
             @RequestParam("prompt") String prompt) throws IOException {
 
-        // 아직 DB 연결 전이므로, 포스트맨에서 프롬프트를 직접 입력받아 테스트
-        AiVerificationResponse response = aiService.verifyMissionImage(image, prompt);
-        return ResponseEntity.ok(response);
+        AiVerificationResponse result = aiService.verifyMissionImage(image, prompt);
+        // APIResponse 포맷으로 반환
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, result);
     }
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/entity/Mission.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/entity/Mission.java
@@ -4,13 +4,14 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import me.sogom.bridge.domain.common.BaseEntity;
 import me.sogom.bridge.domain.member.entity.Parent;
 //mission entity
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "mission")
-public class Mission {
+public class Mission extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "mission_id")
     private Long id;
@@ -21,7 +22,4 @@ public class Mission {
 
     @Column(nullable = false, length = 50)
     private String title;
-
-    @Column(name = "created_at")
-    private String createdAt;
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/entity/MissionPerformance.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/entity/MissionPerformance.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import me.sogom.bridge.domain.common.BaseEntity;
 import me.sogom.bridge.domain.member.entity.Children;
 //mission 수행 내역 entity
 @Entity
@@ -12,7 +13,7 @@ import me.sogom.bridge.domain.member.entity.Children;
 @Setter // 상태 업데이트를 위해 일시적 허용 (실무에선 update 메서드 사용 권장)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "mission_performance")
-public class MissionPerformance {
+public class MissionPerformance extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "mission_performance_id")
     private Long id;

--- a/src/main/java/me/sogom/bridge/domain/mission/entity/MissionPerformance.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/entity/MissionPerformance.java
@@ -26,7 +26,7 @@ public class MissionPerformance {
     private Children child;
 
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "ENUM('PENDING', 'ACCEPTED', 'REJECTED') DEFAULT 'PENDING'")
+    @Column(nullable = false) // 옵션: null 허용 안함, PostgreSQL 문법
     private MissionStatus status; // PENDING, ACCEPTED, REJECTED
 
     @Column(name = "proof_url", length = 500)

--- a/src/main/java/me/sogom/bridge/domain/mission/exception/MissionErrorCode.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/exception/MissionErrorCode.java
@@ -1,0 +1,19 @@
+package me.sogom.bridge.domain.mission.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import me.sogom.bridge.global.apiPayload.code.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MissionErrorCode implements BaseErrorCode {
+
+    MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION404", "해당 미션을 찾을 수 없습니다."),
+    AI_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MISSION500", "AI 판독 결과를 처리하는 중 오류가 발생했습니다.");
+    // 필요할 때마다 여기에 추가 예정
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/exception/MissionException.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/exception/MissionException.java
@@ -1,0 +1,10 @@
+package me.sogom.bridge.domain.mission.exception;
+
+import me.sogom.bridge.global.apiPayload.code.BaseErrorCode;
+import me.sogom.bridge.global.apiPayload.exception.ProjectException;
+
+public class MissionException extends ProjectException {
+    public MissionException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    # 도커로 띄운 PostgreSQL 주소
+    url: jdbc:postgresql://localhost:5432/postgres
+    username: postgres
+    password: ${LOCAL_DB_PASSWORD} # 도커 실행 시 설정한 비밀번호
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      # 테이블 자동 업데이트
+      ddl-auto: update
+    database: postgresql
+    database-platform: org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    # H2를 PostgreSQL 모드로 동작하게 설정 (ERD 호환성)
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      # 테스트 실행 시마다 테이블을 새로 만들고 종료 시 삭제합니다.
+      ddl-auto: create-drop

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,11 @@
 spring:
+  profiles:
+    active: local # 기본적으로 local 프로필을 활성화
+
   application:
     name: Bridge
 
+  # 기존 Gemini 설정 유지
   ai:
     google:
       genai:
@@ -9,7 +13,17 @@ spring:
         chat:
           options:
             model: gemini-2.5-flash
+
+  # 기존 파일 업로드 설정 유지
   servlet:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
+
+  jpa:
+    open-in-view: false
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true


### PR DESCRIPTION
## 주요 변경 사항
 - [x] 주요 엔티티(Mission, MissionPerformance, Children, Parent) BaseEntity를 상속받도록 수정 및 중복 컬럼 삭제
 - [x] MissionController 등 컨트롤러의 모든 API 반환 형식을 ApiResponse로 통일.
 - [x] AI 판독 결과(AiVerificationResponse) 등 DTO의 구조를 리팩토링된 엔티티 필드와 매핑되도록 최적화.
 - [x] BaseErrorCode, ProjectException 등을 참고하여 MissionException과 MissionErrorCode 작성


관련 이슈/마일스톤
- Closes https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/8
- Relates to https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/8