### PR TITLE
Feat: AI 판독 결과 DB 저장 및 상태 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 
     // H2 메모리 데이터베이스 (테스트용)
     runtimeOnly 'com.h2database:h2'
+
+    // PostgreSQL 드라이버
+    runtimeOnly 'org.postgresql:postgresql'
 }
 
 // 6. 의존성 관리 (BOM): Spring AI와 관련된 수많은 하위 라이브러리들의 버전을 1.1.3으로 일관되게 맞춰주어 버전 충돌을 방지합니다.

--- a/src/main/java/me/sogom/bridge/domain/member/entity/Children.java
+++ b/src/main/java/me/sogom/bridge/domain/member/entity/Children.java
@@ -4,14 +4,13 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
+import me.sogom.bridge.domain.common.BaseEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "children")
-public class Children {
+public class Children extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "children_id")
     private Long id;
@@ -27,7 +26,4 @@ public class Children {
 
     @Column(length = 6)
     private String code; // 자녀 연동 코드
-
-    @Column(name = "created_at")
-    private LocalDateTime createdAt;
 }

--- a/src/main/java/me/sogom/bridge/domain/member/repository/ChildrenRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/member/repository/ChildrenRepository.java
@@ -1,0 +1,8 @@
+package me.sogom.bridge.domain.member.repository;
+
+import me.sogom.bridge.domain.member.entity.Children;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// Children 엔티티를 관리하는 리포지토리
+public interface ChildrenRepository extends JpaRepository<Children, Long> {
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
@@ -3,8 +3,9 @@ package me.sogom.bridge.domain.mission.controller;
 import lombok.RequiredArgsConstructor;
 import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
 import me.sogom.bridge.domain.mission.service.MissionVerificationAiService;
+import me.sogom.bridge.global.apiPayload.ApiResponse;
+import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -21,12 +22,12 @@ public class MissionController {
     private final MissionVerificationAiService aiService;
 
     @PostMapping(value = "/verify-test", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<AiVerificationResponse> testVerification(
+    public ApiResponse<AiVerificationResponse> testVerification( //return type 변경
             @RequestParam("image") MultipartFile image,
             @RequestParam("prompt") String prompt) throws IOException {
 
-        // 아직 DB 연결 전이므로, 포스트맨에서 프롬프트를 직접 입력받아 테스트
-        AiVerificationResponse response = aiService.verifyMissionImage(image, prompt);
-        return ResponseEntity.ok(response);
+        AiVerificationResponse result = aiService.verifyMissionImage(image, prompt);
+        // APIResponse 포맷으로 반환
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, result);
     }
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
@@ -2,14 +2,11 @@ package me.sogom.bridge.domain.mission.controller;
 
 import lombok.RequiredArgsConstructor;
 import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
-import me.sogom.bridge.domain.mission.service.MissionVerificationAiService;
+import me.sogom.bridge.domain.mission.service.MissionPerformanceService; // 변경: 통합 서비스 임포트
 import me.sogom.bridge.global.apiPayload.ApiResponse;
 import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*; // PathVariable 등을 위해 추가
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -19,14 +16,20 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class MissionController {
 
-    private final MissionVerificationAiService aiService;
+    // 변경: AI 전담 서비스 대신, DB 저장까지 책임지는 MissionPerformanceService를 주입
+    private final MissionPerformanceService performanceService;
 
-    @PostMapping(value = "/verify-test", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<AiVerificationResponse> testVerification( //return type 변경
-            @RequestParam("image") MultipartFile image,
+    //자녀의 미션 수행 인증 API
+    @PostMapping(value = "/{missionId}/performances", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<AiVerificationResponse> performMission(
+            @PathVariable("missionId") Long missionId,      // 어떤 미션인지 (경로 변수)
+            @RequestParam("childId") Long childId,          // 수행하는 자녀가 누구인지
+            @RequestParam("image") MultipartFile image,     // 인증 사진
             @RequestParam("prompt") String prompt) throws IOException {
 
-        AiVerificationResponse result = aiService.verifyMissionImage(image, prompt);
+        // Service에서 권한 검증 -> AI 판독 -> DB 저장(reason 포함)을 한 번에 처리 후 결과 반환
+        AiVerificationResponse result = performanceService.verifyAndSaveMission(missionId, childId, image, prompt);
+        
         // APIResponse 포맷으로 반환
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, result);
     }

--- a/src/main/java/me/sogom/bridge/domain/mission/entity/Mission.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/entity/Mission.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import me.sogom.bridge.domain.common.BaseEntity;
+import me.sogom.bridge.domain.member.entity.Children;
 import me.sogom.bridge.domain.member.entity.Parent;
 //mission entity
 @Entity
@@ -15,6 +16,10 @@ public class Mission extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "mission_id")
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "child_id", nullable = false)
+    private Children child;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id", nullable = false)

--- a/src/main/java/me/sogom/bridge/domain/mission/entity/Mission.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/entity/Mission.java
@@ -4,13 +4,14 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import me.sogom.bridge.domain.common.BaseEntity;
 import me.sogom.bridge.domain.member.entity.Parent;
 //mission entity
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "mission")
-public class Mission {
+public class Mission extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "mission_id")
     private Long id;
@@ -21,7 +22,4 @@ public class Mission {
 
     @Column(nullable = false, length = 50)
     private String title;
-
-    @Column(name = "created_at")
-    private String createdAt;
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/entity/MissionPerformance.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/entity/MissionPerformance.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import me.sogom.bridge.domain.common.BaseEntity;
 import me.sogom.bridge.domain.member.entity.Children;
 //mission 수행 내역 entity
 @Entity
@@ -12,7 +13,7 @@ import me.sogom.bridge.domain.member.entity.Children;
 @Setter // 상태 업데이트를 위해 일시적 허용 (실무에선 update 메서드 사용 권장)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "mission_performance")
-public class MissionPerformance {
+public class MissionPerformance extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "mission_performance_id")
     private Long id;

--- a/src/main/java/me/sogom/bridge/domain/mission/entity/MissionPerformance.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/entity/MissionPerformance.java
@@ -1,16 +1,14 @@
 package me.sogom.bridge.domain.mission.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import me.sogom.bridge.domain.common.BaseEntity;
 import me.sogom.bridge.domain.member.entity.Children;
 //mission 수행 내역 entity
 @Entity
 @Getter
-@Setter // 상태 업데이트를 위해 일시적 허용 (실무에선 update 메서드 사용 권장)
+@Builder
+@AllArgsConstructor //@Builder를 쓰기 위한 필수 세트
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "mission_performance")
 public class MissionPerformance extends BaseEntity {
@@ -32,4 +30,7 @@ public class MissionPerformance extends BaseEntity {
 
     @Column(name = "proof_url", length = 500)
     private String proofUrl;
+
+    @Column(name = "reason", columnDefinition = "TEXT") //AI의 분석 근거를 저장할 컬럼 추가
+    private String reason;
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/entity/MissionPerformance.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/entity/MissionPerformance.java
@@ -26,7 +26,7 @@ public class MissionPerformance {
     private Children child;
 
     @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "ENUM('PENDING', 'ACCEPTED', 'REJECTED') DEFAULT 'PENDING'")
+    @Column(nullable = false) // 옵션: null 허용 안함, PostgreSQL 문법
     private MissionStatus status; // PENDING, ACCEPTED, REJECTED
 
     @Column(name = "proof_url", length = 500)

--- a/src/main/java/me/sogom/bridge/domain/mission/exception/MissionErrorCode.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/exception/MissionErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum MissionErrorCode implements BaseErrorCode {
 
     MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION404", "해당 미션을 찾을 수 없습니다."),
-    AI_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MISSION500", "AI 판독 결과를 처리하는 중 오류가 발생했습니다.");
+    AI_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MISSION500", "AI 판독 결과를 처리하는 중 오류가 발생했습니다."),
+    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "MISSION403", "해당 미션에 대한 수행 권한이 없습니다."); //권한 검증 실패 시 사용
     // 필요할 때마다 여기에 추가 예정
 
     private final HttpStatus status;

--- a/src/main/java/me/sogom/bridge/domain/mission/exception/MissionErrorCode.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/exception/MissionErrorCode.java
@@ -1,0 +1,19 @@
+package me.sogom.bridge.domain.mission.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import me.sogom.bridge.global.apiPayload.code.BaseErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MissionErrorCode implements BaseErrorCode {
+
+    MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION404", "해당 미션을 찾을 수 없습니다."),
+    AI_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MISSION500", "AI 판독 결과를 처리하는 중 오류가 발생했습니다.");
+    // 필요할 때마다 여기에 추가 예정
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/exception/MissionException.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/exception/MissionException.java
@@ -1,0 +1,10 @@
+package me.sogom.bridge.domain.mission.exception;
+
+import me.sogom.bridge.global.apiPayload.code.BaseErrorCode;
+import me.sogom.bridge.global.apiPayload.exception.ProjectException;
+
+public class MissionException extends ProjectException {
+    public MissionException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/repository/MissionPerformanceRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/repository/MissionPerformanceRepository.java
@@ -1,0 +1,8 @@
+package me.sogom.bridge.domain.mission.repository;
+
+import me.sogom.bridge.domain.mission.entity.MissionPerformance;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// DB에 접근하여 저장/조회를 담당
+public interface MissionPerformanceRepository extends JpaRepository<MissionPerformance, Long> {
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/repository/MissionRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/repository/MissionRepository.java
@@ -1,0 +1,8 @@
+package me.sogom.bridge.domain.mission.repository;
+
+import me.sogom.bridge.domain.mission.entity.Mission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// Mission 엔티티를 관리하는 리포지토리
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
@@ -1,0 +1,62 @@
+package me.sogom.bridge.domain.mission.service;
+
+import lombok.RequiredArgsConstructor;
+import me.sogom.bridge.domain.member.entity.Children;
+import me.sogom.bridge.domain.member.repository.ChildrenRepository;
+import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
+import me.sogom.bridge.domain.mission.entity.Mission;
+import me.sogom.bridge.domain.mission.entity.MissionPerformance;
+import me.sogom.bridge.domain.mission.entity.MissionStatus;
+import me.sogom.bridge.domain.mission.exception.MissionErrorCode;
+import me.sogom.bridge.domain.mission.exception.MissionException;
+import me.sogom.bridge.domain.mission.repository.MissionPerformanceRepository;
+import me.sogom.bridge.domain.mission.repository.MissionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class MissionPerformanceService {
+
+    private final MissionPerformanceRepository performanceRepository;
+    private final MissionRepository missionRepository;
+    private final ChildrenRepository childrenRepository; // 자녀 조회
+    private final MissionVerificationAiService aiService;
+
+    @Transactional // 데이터를 DB에 반영하기 위해 반드시 필요
+    public AiVerificationResponse verifyAndSaveMission(Long missionId, Long childId, MultipartFile image, String prompt) throws IOException {
+
+        //미션과 자녀 정보 조회 (예외 던지기 적용)
+        Mission mission = missionRepository.findById(missionId)
+                .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
+        Children child = childrenRepository.findById(childId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 자녀를 찾을 수 없습니다.")); // ChildrenException 생략
+
+        //연관관계 검증 (이 미션이 지금 요청한 아이의 미션이 맞는지 확인하는 로직 추가 가능)
+        // 미션 엔티티에 저장된 자녀 ID와 현재 수행하려는 자녀 ID가 일치하는지 바로 확인
+        if (!mission.getChild().getId().equals(childId)) {
+            throw new MissionException(MissionErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        //AI 판독 요청 (기존 MissionVerificationAiService 호출)
+        AiVerificationResponse aiResponse = aiService.verifyMissionImage(image, prompt);
+
+        //(Builder 패턴을 사용해서 객체 조립 (아직 이미지 X)
+        MissionPerformance performance = MissionPerformance.builder()
+                .mission(mission)
+                .child(child)
+                .status(aiResponse.isAccepted() ? MissionStatus.ACCEPTED : MissionStatus.REJECTED)
+                .reason(aiResponse.reason())
+                .build();
+        //사진 URL은 나중에 S3 같은 곳에 올리고 URL을 받아 넣어야 함
+
+        //최종적으로 DB에 영속화 (Save)
+        performanceRepository.save(performance);
+
+        //프론트엔드에게 돌려줄 AI 응답 반환
+        return aiResponse;
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    # 도커로 띄운 PostgreSQL 주소
+    url: jdbc:postgresql://localhost:5432/postgres
+    username: postgres
+    password: ${LOCAL_DB_PASSWORD} # 도커 실행 시 설정한 비밀번호
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      # 테이블 자동 업데이트
+      ddl-auto: update
+    database: postgresql
+    database-platform: org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    # H2를 PostgreSQL 모드로 동작하게 설정 (ERD 호환성)
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      # 테스트 실행 시마다 테이블을 새로 만들고 종료 시 삭제합니다.
+      ddl-auto: create-drop

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,11 @@
 spring:
+  profiles:
+    active: local # 기본적으로 local 프로필을 활성화
+
   application:
     name: Bridge
 
+  # 기존 Gemini 설정 유지
   ai:
     google:
       genai:
@@ -9,7 +13,17 @@ spring:
         chat:
           options:
             model: gemini-2.5-flash
+
+  # 기존 파일 업로드 설정 유지
   servlet:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
+
+  jpa:
+    open-in-view: false
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true


### PR DESCRIPTION
## 📄 작업 내용 요약
Gemini AI가 분석한 미션 판독 결과(isAccepted, reason)를 mission_performance 테이블에 영구 저장하여 자녀의 미션 수행 히스토리를 데이터베이스 수준에서 관리하도록 구현함

다른 자녀의 미션에 접근하지 못하도록 연관관계 검증을 추가함

공통 예외 처리 및 응답 규격을 적용함

## 👀 주요 변경 사항
### 엔티티 필드 확장 및 연관관계 수정

- [x] MissionPerformance 엔티티에 AI 피드백을 저장할 reason 필드(TEXT 타입) 추가 및 @Builder 패턴 적용

- [x] Mission 엔티티에 미션 수행 주체를 명확히 하기 위해 child 연관관계(child_id) 추가

### Repository 생성

- [x] 데이터 조작을 위한 MissionPerformanceRepository, MissionRepository, ChildrenRepository 인터페이스 생성

### 핵심 비즈니스 로직(MissionPerformanceService) 구현

- [x] AI 응답 데이터를 바탕으로 MissionStatus(ACCEPTED, REJECTED)를 판단하고 DB에 save() 하는 영속화 흐름 제어

### 연관관계 검증 및 예외 처리 강화

- [x] 보안 검증: 요청한 자녀(childId)와 미션에 할당된 자녀(mission.getChild())가 일치하는지 확인하는 방어 로직 추가

- [x] 예외 처리: 검증 실패 시 MissionException(UNAUTHORIZED_ACCESS, MISSION403)을 던지도록 MissionErrorCode 확장

### Controller 엔드포인트 및 응답 규격화

- [x] API 주소를 리팩토링 (POST /api/v1/missions/{missionId}/performances)

## 📎 관련 이슈/마일스톤
- Closes https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/10
- Relates to https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/10