### PR TITLE
Feat: 자녀 앱 차단 정책 조회 API 구현

### DIFF
--- a/src/main/java/me/sogom/bridge/domain/policy/controller/ChildPolicyController.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/controller/ChildPolicyController.java
@@ -1,0 +1,30 @@
+package me.sogom.bridge.domain.policy.controller;
+
+import lombok.RequiredArgsConstructor;
+import me.sogom.bridge.domain.policy.dto.PolicyResponse;
+import me.sogom.bridge.domain.policy.service.ChildPolicyService;
+import me.sogom.bridge.global.apiPayload.ApiResponse;
+import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/children")
+@RequiredArgsConstructor
+public class ChildPolicyController {
+
+    private final ChildPolicyService childPolicyService;
+
+    /*
+     자녀 앱용 정책 조회 API
+     자녀 앱 구동 시 필요한 시간 제한 및 앱 차단 리스트를 반환
+     */
+    @GetMapping("/{childId}/policies")
+    public ApiResponse<PolicyResponse> getChildPolicy(@PathVariable("childId") Long childId) {
+
+        // Service를 호출하여 이번 달 정책과 차단 앱 목록을 가져옴
+        PolicyResponse response = childPolicyService.getChildPolicy(childId);
+
+        // ApiResponse 형식에 담아서 반환
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, response);
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/policy/dto/PolicyResponse.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/dto/PolicyResponse.java
@@ -1,0 +1,29 @@
+package me.sogom.bridge.domain.policy.dto;
+
+import lombok.*;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PolicyResponse {
+
+    //시간 정책 관련 데이터
+    private int totalAvailableTime;    // 이번 달 쓸 수 있는 총 시간 (기본 + 보상 합계)
+    private int baseTime;              // 부모님이 설정한 순수 기본 시간
+    private int accumulatedRewardTime; // 미션으로 모은 보상 시간
+
+    //앱 차단 관련 데이터
+    private List<AppBlockInfo> blockedApps; // 차단된 앱들의 상세 리스트
+
+    //차단 앱의 정보를 담는 내부 DTO
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class AppBlockInfo {
+        private String appName;     // 앱 이름 (예: 인스타그램)
+        private String packageName; // 패키지명 (예: com.instagram.android)
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/policy/entity/AppBlock.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/entity/AppBlock.java
@@ -1,0 +1,29 @@
+package me.sogom.bridge.domain.policy.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import me.sogom.bridge.domain.common.BaseEntity;
+import me.sogom.bridge.domain.member.entity.Children;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "app_block")
+public class AppBlock extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "app_block_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "children_id", nullable = false)
+    private Children child; // 차단이 적용되는 자녀
+
+    @Column(nullable = false, length = 100)
+    private String appName; // 앱 이름 (예: "인스타그램")
+
+    @Column(nullable = false, length = 255)
+    private String packageName; // 안드로이드 패키지명 (예: "com.instagram.android")
+}

--- a/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
@@ -1,0 +1,47 @@
+package me.sogom.bridge.domain.policy.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import me.sogom.bridge.domain.common.BaseEntity;
+import me.sogom.bridge.domain.member.entity.Children;
+import me.sogom.bridge.domain.member.entity.Parent;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "time_policy")
+public class TimePolicy extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "time_policy_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id", nullable = false)
+    private Parent parent;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "children_id", nullable = false) // 자녀 테이블 PK 이름에 맞춤
+    private Children child;
+
+    @Column(nullable = false)
+    private int baseTime; // 부모님이 설정한 기본 시간 (분)
+
+    @Column(nullable = false)
+    private int accumulatedRewardTime; // 미션 성공으로 쌓인 총 보상 시간 (분)
+
+    @Column(nullable = false, length = 7)
+    private String yearMonth; // 해당 정책의 년월 (예: "2026-04")
+
+    // 보상 시간 추가 메서드
+    public void addReward(int rewardMinutes) {
+        this.accumulatedRewardTime += rewardMinutes;
+    }
+
+    // 자녀가 조회할 '사용 가능한 총 시간' 계산
+    public int getTotalAvailableTime() {
+        return this.baseTime + this.accumulatedRewardTime;
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/policy/repository/AppBlockRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/repository/AppBlockRepository.java
@@ -1,0 +1,11 @@
+package me.sogom.bridge.domain.policy.repository;
+
+import me.sogom.bridge.domain.policy.entity.AppBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AppBlockRepository extends JpaRepository<AppBlock, Long> {
+    //특정 자녀에게 걸려있는 모든 차단 앱을 가져옴
+    List<AppBlock> findAllByChildId(Long childId);
+}

--- a/src/main/java/me/sogom/bridge/domain/policy/repository/TimePolicyRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/repository/TimePolicyRepository.java
@@ -1,0 +1,12 @@
+package me.sogom.bridge.domain.policy.repository;
+
+import me.sogom.bridge.domain.policy.entity.TimePolicy;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TimePolicyRepository extends JpaRepository<TimePolicy, Long> {
+    //특정 자녀의 특정 연월 정책을 하나 찾아옴
+    // 예: childId=1, yearMonth="2026-04"
+    Optional<TimePolicy> findByChildIdAndYearMonth(Long childId, String yearMonth);
+}

--- a/src/main/java/me/sogom/bridge/domain/policy/service/ChildPolicyService.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/service/ChildPolicyService.java
@@ -1,0 +1,49 @@
+package me.sogom.bridge.domain.policy.service;
+
+import lombok.RequiredArgsConstructor;
+import me.sogom.bridge.domain.policy.dto.PolicyResponse;
+import me.sogom.bridge.domain.policy.entity.AppBlock;
+import me.sogom.bridge.domain.policy.entity.TimePolicy;
+import me.sogom.bridge.domain.policy.repository.AppBlockRepository;
+import me.sogom.bridge.domain.policy.repository.TimePolicyRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.YearMonth;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChildPolicyService {
+
+    private final TimePolicyRepository timePolicyRepository;
+    private final AppBlockRepository appBlockRepository;
+
+    //자녀 앱 구동 시 현재 정책(시간 및 차단 앱) 조회
+    public PolicyResponse getChildPolicy(Long childId) {
+        //현재 년월 구하기 (예: "2026-04")
+        String currentYearMonth = YearMonth.now().toString();
+
+        //이번 달 시간 정책 조회 (없으면 예외 발생)
+        TimePolicy timePolicy = timePolicyRepository.findByChildIdAndYearMonth(childId, currentYearMonth)
+                .orElseThrow(() -> new IllegalArgumentException("이번 달에 설정된 시간 정책이 없습니다."));
+
+        //차단 앱 목록 조회
+        List<AppBlock> appBlocks = appBlockRepository.findAllByChildId(childId);
+
+        //엔티티들을 DTO로 변환하여 반환
+        return PolicyResponse.builder()
+                .totalAvailableTime(timePolicy.getTotalAvailableTime())
+                .baseTime(timePolicy.getBaseTime())
+                .accumulatedRewardTime(timePolicy.getAccumulatedRewardTime())
+                .blockedApps(appBlocks.stream()
+                        .map(app -> PolicyResponse.AppBlockInfo.builder()
+                                .appName(app.getAppName())
+                                .packageName(app.getPackageName())
+                                .build())
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
- [x] Policy 관련 Entity 생성 (AppBlock, TimePolicy)
- [x] DTO, Repository 작성
- [x] '이번 달 사용 제한 시간 총량'과 '앱 차단 리스트'를 서버에서 조회
- [x] 클라이언트로 전달하는 GET API를 구현

## 👀 주요 변경 사항
* **엔티티 설계**
    * 부모가 설정한 시간 총량과 미션 보상을 관리하는 `TimePolicy` 엔티티 생성
    * 차단 대상 앱의 패키지명 정보를 관리하는 `AppBlock` 엔티티 생성
* **DTO 설계**
    * 클라이언트의 호출 횟수를 줄이기 위해, 시간 정보와 차단 앱 리스트를 한 번에 묶어 반환하는 `PolicyResponse` 통합 DTO 구현
* **Repository 및 비즈니스 로직 (`ChildPolicyService`)**
    * 부모 앱 로직과의 충돌을 방지하기 위해 자녀 전용 서비스 클래스(`ChildPolicyService`)로 분리하여 명확한 협업 구조 확립
    * 특정 자녀(`childId`)의 현재 달(`YearMonth.now()`) 기준 시간 정책을 가져오고, `baseTime`과 `accumulatedRewardTime`을 합산하여 `totalAvailableTime`을 클라이언트에 제공
* **Controller 엔드포인트**
    * `GET /api/v1/children/{childId}/policies` 엔드포인트 생성
    * 팀 공통 응답 포맷인 `ApiResponse` 규격 적용

## 📎 Issue 번호
- Closes https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/12
- Relates to https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/12