### PR TITLE
Feat: 미션 카테고리별 AI 맞춤형 판독 로직 고도화 및 연동 버그 수정

### DIFF
--- a/src/main/java/me/sogom/bridge/domain/member/service/ParentService.java
+++ b/src/main/java/me/sogom/bridge/domain/member/service/ParentService.java
@@ -46,7 +46,7 @@ public class ParentService {
 
         // 자녀 정보 업데이트
         children.setParent(parent);
-        children.setBirth(request.birth());
+        children.setBirth(request.childrenBirth());
         children.setProfileImageUrl(request.profileImageUrl());
 
         childrenRepository.save(children);

--- a/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
@@ -2,6 +2,7 @@ package me.sogom.bridge.domain.mission.controller;
 
 import lombok.RequiredArgsConstructor;
 import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
+import me.sogom.bridge.domain.mission.entity.MissionCategory;
 import me.sogom.bridge.domain.mission.service.MissionPerformanceService; // 변경: 통합 서비스 임포트
 import me.sogom.bridge.global.apiPayload.ApiResponse;
 import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
@@ -25,11 +26,11 @@ public class MissionController {
             @PathVariable("missionId") Long missionId,      // 어떤 미션인지 (경로 변수)
             @RequestParam("childId") Long childId,          // 수행하는 자녀가 누구인지
             @RequestParam("image") MultipartFile image,     // 인증 사진
+            @RequestParam("category") MissionCategory category, //카테고리
             @RequestParam("prompt") String prompt) throws IOException {
 
         // Service에서 권한 검증 -> AI 판독 -> DB 저장(reason 포함)을 한 번에 처리 후 결과 반환
-        AiVerificationResponse result = performanceService.verifyAndSaveMission(missionId, childId, image, prompt);
-        
+        AiVerificationResponse result = performanceService.verifyAndSaveMission(missionId, childId, image, prompt, category);
         // APIResponse 포맷으로 반환
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, result);
     }

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
@@ -5,6 +5,7 @@ import me.sogom.bridge.domain.member.entity.Children;
 import me.sogom.bridge.domain.member.repository.ChildrenRepository;
 import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
 import me.sogom.bridge.domain.mission.entity.Mission;
+import me.sogom.bridge.domain.mission.entity.MissionCategory;
 import me.sogom.bridge.domain.mission.entity.MissionPerformance;
 import me.sogom.bridge.domain.mission.entity.MissionStatus;
 import me.sogom.bridge.domain.mission.exception.MissionErrorCode;
@@ -27,8 +28,7 @@ public class MissionPerformanceService {
     private final MissionVerificationAiService aiService;
 
     @Transactional // 데이터를 DB에 반영하기 위해 반드시 필요
-    public AiVerificationResponse verifyAndSaveMission(Long missionId, Long childId, MultipartFile image, String prompt) throws IOException {
-
+    public AiVerificationResponse verifyAndSaveMission(Long missionId, Long childId, MultipartFile image, String prompt, MissionCategory category) throws IOException {
         //미션과 자녀 정보 조회 (예외 던지기 적용)
         Mission mission = missionRepository.findById(missionId)
                 .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
@@ -42,7 +42,7 @@ public class MissionPerformanceService {
         }
 
         //AI 판독 요청 (기존 MissionVerificationAiService 호출)
-        AiVerificationResponse aiResponse = aiService.verifyMissionImage(image, prompt);
+        AiVerificationResponse aiResponse = aiService.verifyMissionImage(image, category, prompt);
 
         //(Builder 패턴을 사용해서 객체 조립 (아직 이미지 X)
         MissionPerformance performance = MissionPerformance.builder()

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPromptProvider.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPromptProvider.java
@@ -1,0 +1,27 @@
+package me.sogom.bridge.domain.mission.service;
+
+import me.sogom.bridge.domain.mission.entity.MissionCategory;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class MissionPromptProvider {
+
+    // 카테고리별 맞춤형 검증 프롬프트 맵핑
+    private static final Map<MissionCategory, String> PROMPTS = Map.of(
+            MissionCategory.CLEANING, "사진에 쓰레기가 없고, 물건들이 정돈되어 있으며, 청소가 완료된 깨끗한 공간인지 분석해 줘.",
+            MissionCategory.STUDY, "사진에 펼쳐진 책, 필기구, 노트 등 공부를 한 명확한 증거가 있는지 분석해 줘. 덜 풀린 문제가 있는 경우엔 fail 처리 해줘",
+            MissionCategory.EXERCISE, "사진에 헬스장, 운동 기구, 혹은 운동복을 입고 운동 중인 모습 등 명확한 증거가 있는지 분석해 줘. 등장하는 인물이 있다면 운동을 한 모습인지 분석해줘",
+            MissionCategory.READING, "사진에 글자가 선명하게 보이는 펼쳐진 책 페이지나 독서 중인 모습, 또는 독후감이 포함되어 있는지 분석해 줘. 독후감이라면 독후감의 내용이 너무 짧지 않은지 파악해줘",
+            MissionCategory.ETC, "주어진 사진이 특정 미션을 성공적으로 완수한 모습인지 일반적인 기준으로 분석해 줘."
+    );
+
+    public String getPrompt(MissionCategory category) {
+        // 카테고리가 null이거나 목록에 없으면 ETC(기타) 프롬프트를 기본으로 반환
+        if (category == null || !PROMPTS.containsKey(category)) {
+            return PROMPTS.get(MissionCategory.ETC);
+        }
+        return PROMPTS.get(category);
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionVerificationAiService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionVerificationAiService.java
@@ -1,6 +1,7 @@
 package me.sogom.bridge.domain.mission.service;
 
 import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
+import me.sogom.bridge.domain.mission.entity.MissionCategory;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.stereotype.Service;
@@ -13,22 +14,34 @@ import java.io.IOException;
 public class MissionVerificationAiService {
 
     private final ChatClient chatClient;
+    private final MissionPromptProvider promptProvider; //프롬프트 제공자 추가
 
-    public MissionVerificationAiService(ChatClient.Builder builder) {
+    //생성자를 통해 PromptProvider 주입
+    public MissionVerificationAiService(ChatClient.Builder builder, MissionPromptProvider promptProvider) {
         this.chatClient = builder.build();
+        this.promptProvider = promptProvider;
     }
 
-    public AiVerificationResponse verifyMissionImage(MultipartFile imageFile, String parentPrompt) throws IOException {
+    //파라미터에 'MissionCategory category' 추가
+    public AiVerificationResponse verifyMissionImage(MultipartFile imageFile, MissionCategory category, String parentPrompt) throws IOException {
 
         // 람다식(u -> u) 안으로 들어가기 전에 미리 getBytes()를 실행
         // 여기서 발생하는 에러는 메서드에 붙은 throws IOException이 처리
         byte[] imageBytes = imageFile.getBytes();
 
-        // 역할과 규칙을 보다 엄격하게 부여
+        //카테고리에 맞는 AI 판독 기준 가져오기
+        String categoryPrompt = promptProvider.getPrompt(category);
 
-        String systemInstruction = """
+        //부모님이 직접 작성한 요구사항이 있다면 합치기 (없으면 카테고리 기본값만 사용)
+        String finalCondition = (parentPrompt != null && !parentPrompt.isBlank())
+                ? "부모님 특별 요청: [" + parentPrompt + "]\n기본 검증 기준: [" + categoryPrompt + "]"
+                : "기본 검증 기준: [" + categoryPrompt + "]";
+
+        // String.format을 이용해 %s 자리에 finalCondition 주입
+        String systemInstruction = String.format("""
     당신은 학생들의 올바른 습관 형성을 돕는 전문적이고 이성적인 'AI 학습 멘토'입니다.
-    부모님이 설정한 미션 통과 기준은 다음과 같습니다: [%s]
+    이번 미션의 통과 기준은 다음과 같습니다:
+    %s
     
     [평가 원칙: 융통성과 변별력의 조화]
     1. 객관적 기준 적용: 미션의 핵심 요소가 누락되었다면 냉정하게 거절(false)하세요. 
@@ -48,7 +61,7 @@ public class MissionVerificationAiService {
     반드시 JSON 형식으로 응답하세요.
     - isAccepted: (true/false)
     - reason: (논리적이고 성숙한 피드백 메시지)
-    """.formatted(parentPrompt);
+    """, finalCondition); // 여기에 주입
 
         return chatClient.prompt()
                 .user(u -> u


### PR DESCRIPTION
## 주요 변경사항
- [x] MissionPromptProvider.java에 각 카테고리 별 프롬프트 추가
- [x] Controller와 Service에 category 파라미터 추가
- [x] 가벼운 변수명 수정

## 테스트
- [x] CLEANING category에 적합한 input을 넣어 ACCEPTED가 나오는걸 확인
- [x] STUDY category에 적합하지 않은 input을 넣어 REJECTED가 나오는걸 확인

## 관련된 이슈
- Closes https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/24
- Relates to https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/24