### PR TITLE
Feat: 미션 승인 시 보상 시간 실시간 정산 및 중복 제출 방지 가드 로직 구현

### DIFF
--- a/src/main/java/me/sogom/bridge/domain/member/service/ParentService.java
+++ b/src/main/java/me/sogom/bridge/domain/member/service/ParentService.java
@@ -46,7 +46,7 @@ public class ParentService {
 
         // 자녀 정보 업데이트
         children.setParent(parent);
-        children.setBirth(request.birth());
+        children.setBirth(request.childrenBirth());
         children.setProfileImageUrl(request.profileImageUrl());
 
         childrenRepository.save(children);

--- a/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
@@ -2,6 +2,7 @@ package me.sogom.bridge.domain.mission.controller;
 
 import lombok.RequiredArgsConstructor;
 import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
+import me.sogom.bridge.domain.mission.entity.MissionCategory;
 import me.sogom.bridge.domain.mission.service.MissionPerformanceService; // 변경: 통합 서비스 임포트
 import me.sogom.bridge.global.apiPayload.ApiResponse;
 import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
@@ -25,11 +26,11 @@ public class MissionController {
             @PathVariable("missionId") Long missionId,      // 어떤 미션인지 (경로 변수)
             @RequestParam("childId") Long childId,          // 수행하는 자녀가 누구인지
             @RequestParam("image") MultipartFile image,     // 인증 사진
+            @RequestParam("category") MissionCategory category, //카테고리
             @RequestParam("prompt") String prompt) throws IOException {
 
         // Service에서 권한 검증 -> AI 판독 -> DB 저장(reason 포함)을 한 번에 처리 후 결과 반환
-        AiVerificationResponse result = performanceService.verifyAndSaveMission(missionId, childId, image, prompt);
-        
+        AiVerificationResponse result = performanceService.verifyAndSaveMission(missionId, childId, image, prompt, category);
         // APIResponse 포맷으로 반환
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, result);
     }

--- a/src/main/java/me/sogom/bridge/domain/mission/entity/MissionPerformance.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/entity/MissionPerformance.java
@@ -33,4 +33,10 @@ public class MissionPerformance extends BaseEntity {
 
     @Column(name = "reason", columnDefinition = "TEXT") //AI의 분석 근거를 저장할 컬럼 추가
     private String reason;
+
+    // AI 판독 결과나 부모 수동 확인에 의해 상태와 판독 이유를 변경하는 비즈니스 메서드
+    public void updateStatusAndReason(MissionStatus status, String reason) {
+        this.status = status;
+        this.reason = reason;
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/exception/MissionErrorCode.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/exception/MissionErrorCode.java
@@ -11,7 +11,8 @@ public enum MissionErrorCode implements BaseErrorCode {
 
     MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION404", "해당 미션을 찾을 수 없습니다."),
     AI_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MISSION500", "AI 판독 결과를 처리하는 중 오류가 발생했습니다."),
-    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "MISSION403", "해당 미션에 대한 수행 권한이 없습니다."); //권한 검증 실패 시 사용
+    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "MISSION403", "해당 미션에 대한 수행 권한이 없습니다."), //권한 검증 실패 시 사용
+    MISSION_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "MISSION400", "이미 완료된 미션입니다.");
     // 필요할 때마다 여기에 추가 예정
 
     private final HttpStatus status;

--- a/src/main/java/me/sogom/bridge/domain/mission/repository/MissionPerformanceRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/repository/MissionPerformanceRepository.java
@@ -3,6 +3,10 @@ package me.sogom.bridge.domain.mission.repository;
 import me.sogom.bridge.domain.mission.entity.MissionPerformance;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 // DB에 접근하여 저장/조회를 담당
 public interface MissionPerformanceRepository extends JpaRepository<MissionPerformance, Long> {
+    //미션 ID로 조회하여 가장 최근에 등록된 내역 1건만 가져오는 메서드
+    Optional<MissionPerformance> findTopByMissionIdOrderByIdDesc(Long missionId);
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/repository/MissionSettingRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/repository/MissionSettingRepository.java
@@ -1,0 +1,10 @@
+package me.sogom.bridge.domain.mission.repository;
+
+import me.sogom.bridge.domain.mission.entity.MissionSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface MissionSettingRepository extends JpaRepository<MissionSetting, String> {
+    // 미션 ID로 세팅 정보(reward가 포함된)를 조회하는 메서드
+    Optional<MissionSetting> findByMissionId(Long missionId);
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
@@ -5,6 +5,7 @@ import me.sogom.bridge.domain.member.entity.Children;
 import me.sogom.bridge.domain.member.repository.ChildrenRepository;
 import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
 import me.sogom.bridge.domain.mission.entity.Mission;
+import me.sogom.bridge.domain.mission.entity.MissionCategory;
 import me.sogom.bridge.domain.mission.entity.MissionPerformance;
 import me.sogom.bridge.domain.mission.entity.MissionStatus;
 import me.sogom.bridge.domain.mission.exception.MissionErrorCode;
@@ -27,8 +28,7 @@ public class MissionPerformanceService {
     private final MissionVerificationAiService aiService;
 
     @Transactional // 데이터를 DB에 반영하기 위해 반드시 필요
-    public AiVerificationResponse verifyAndSaveMission(Long missionId, Long childId, MultipartFile image, String prompt) throws IOException {
-
+    public AiVerificationResponse verifyAndSaveMission(Long missionId, Long childId, MultipartFile image, String prompt, MissionCategory category) throws IOException {
         //미션과 자녀 정보 조회 (예외 던지기 적용)
         Mission mission = missionRepository.findById(missionId)
                 .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
@@ -42,7 +42,7 @@ public class MissionPerformanceService {
         }
 
         //AI 판독 요청 (기존 MissionVerificationAiService 호출)
-        AiVerificationResponse aiResponse = aiService.verifyMissionImage(image, prompt);
+        AiVerificationResponse aiResponse = aiService.verifyMissionImage(image, category, prompt);
 
         //(Builder 패턴을 사용해서 객체 조립 (아직 이미지 X)
         MissionPerformance performance = MissionPerformance.builder()

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
@@ -4,19 +4,20 @@ import lombok.RequiredArgsConstructor;
 import me.sogom.bridge.domain.member.entity.Children;
 import me.sogom.bridge.domain.member.repository.ChildrenRepository;
 import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
-import me.sogom.bridge.domain.mission.entity.Mission;
-import me.sogom.bridge.domain.mission.entity.MissionCategory;
-import me.sogom.bridge.domain.mission.entity.MissionPerformance;
-import me.sogom.bridge.domain.mission.entity.MissionStatus;
+import me.sogom.bridge.domain.mission.entity.*;
 import me.sogom.bridge.domain.mission.exception.MissionErrorCode;
 import me.sogom.bridge.domain.mission.exception.MissionException;
 import me.sogom.bridge.domain.mission.repository.MissionPerformanceRepository;
 import me.sogom.bridge.domain.mission.repository.MissionRepository;
+import me.sogom.bridge.domain.mission.repository.MissionSettingRepository;
+import me.sogom.bridge.domain.policy.entity.TimePolicy;
+import me.sogom.bridge.domain.policy.repository.TimePolicyRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.YearMonth;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +27,8 @@ public class MissionPerformanceService {
     private final MissionRepository missionRepository;
     private final ChildrenRepository childrenRepository; // 자녀 조회
     private final MissionVerificationAiService aiService;
+    private final MissionSettingRepository missionSettingRepository;
+    private final TimePolicyRepository timePolicyRepository;
 
     @Transactional // 데이터를 DB에 반영하기 위해 반드시 필요
     public AiVerificationResponse verifyAndSaveMission(Long missionId, Long childId, MultipartFile image, String prompt, MissionCategory category) throws IOException {
@@ -44,11 +47,35 @@ public class MissionPerformanceService {
         //AI 판독 요청 (기존 MissionVerificationAiService 호출)
         AiVerificationResponse aiResponse = aiService.verifyMissionImage(image, category, prompt);
 
-        //(Builder 패턴을 사용해서 객체 조립 (아직 이미지 X)
+        // 결과에 따른 미션 상태 결정
+        MissionStatus status = aiResponse.isAccepted() ? MissionStatus.ACCEPTED : MissionStatus.REJECTED;
+
+        // 미션 판독 결과가 성공(ACCEPTED)일 때만 실시간 보상 시간 정산 진행
+        if (status == MissionStatus.ACCEPTED) {
+            // 해당 미션에 걸려있는 보상 시간(reward) 가져오기
+            MissionSetting setting = missionSettingRepository.findByMissionId(missionId)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
+            int rewardTime = setting.getReward();
+
+            // 현재 날짜 기준 년월 구하기 (예: "2026-05")
+            String currentYearMonth = YearMonth.now().toString();
+
+            // 자녀의 이번 달 시간 정책 가져와서 보상 시간 누적하기
+            TimePolicy timePolicy = timePolicyRepository.findByChildIdAndYearMonth(childId, currentYearMonth)
+                    .orElseThrow(() -> new IllegalArgumentException("이번 달에 설정된 자녀의 시간 정책(TimePolicy)이 없습니다."));
+
+            // 시간 추가 (엔티티 내부 메서드 호출)
+            timePolicy.addReward(rewardTime);
+
+            // @Transactional 환경이므로 Dirty Checking(변경 감지)이 일어나 자동 저장되지만, 명시적인 가독성을 위해 호출
+            timePolicyRepository.save(timePolicy);
+        }
+
+        // 객체 조립 및 수행 내역 저장
         MissionPerformance performance = MissionPerformance.builder()
                 .mission(mission)
                 .child(child)
-                .status(aiResponse.isAccepted() ? MissionStatus.ACCEPTED : MissionStatus.REJECTED)
+                .status(status)
                 .reason(aiResponse.reason())
                 .build();
         //사진 URL은 나중에 S3 같은 곳에 올리고 URL을 받아 넣어야 함

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
@@ -44,41 +44,66 @@ public class MissionPerformanceService {
             throw new MissionException(MissionErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        //AI 판독 요청 (기존 MissionVerificationAiService 호출)
-        AiVerificationResponse aiResponse = aiService.verifyMissionImage(image, category, prompt);
+        //해당 미션의 가장 최근 수행 내역을 확인합니다.
+        performanceRepository.findTopByMissionIdOrderByIdDesc(missionId)
+                .ifPresent(lastPerformance -> {
+                    // 이미 부모나 AI가 승인(ACCEPTED)한 미션이라면 더 이상 진행하지 못하게 차단!
+                    if (lastPerformance.getStatus() == MissionStatus.ACCEPTED) {
+                        throw new MissionException(MissionErrorCode.MISSION_ALREADY_COMPLETED);
+                        // ➡️ 익셉션 핸들러를 통해 포스트맨에 "이미 완료된 미션입니다" (400) 에러가 예쁘게 나감
+                    }
+                });
 
-        // 결과에 따른 미션 상태 결정
-        MissionStatus status = aiResponse.isAccepted() ? MissionStatus.ACCEPTED : MissionStatus.REJECTED;
-
-        // 미션 판독 결과가 성공(ACCEPTED)일 때만 실시간 보상 시간 정산 진행
-        if (status == MissionStatus.ACCEPTED) {
-            // 해당 미션에 걸려있는 보상 시간(reward) 가져오기
-            MissionSetting setting = missionSettingRepository.findByMissionId(missionId)
-                    .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
-            int rewardTime = setting.getReward();
-
-            // 현재 날짜 기준 년월 구하기 (예: "2026-05")
-            String currentYearMonth = YearMonth.now().toString();
-
-            // 자녀의 이번 달 시간 정책 가져와서 보상 시간 누적하기
-            TimePolicy timePolicy = timePolicyRepository.findByChildIdAndYearMonth(childId, currentYearMonth)
-                    .orElseThrow(() -> new IllegalArgumentException("이번 달에 설정된 자녀의 시간 정책(TimePolicy)이 없습니다."));
-
-            // 시간 추가 (엔티티 내부 메서드 호출)
-            timePolicy.addReward(rewardTime);
-
-            // @Transactional 환경이므로 Dirty Checking(변경 감지)이 일어나 자동 저장되지만, 명시적인 가독성을 위해 호출
-            timePolicyRepository.save(timePolicy);
-        }
-
-        // 객체 조립 및 수행 내역 저장
+        // 2. [PENDING 먼저 저장] AI를 호출하기 전에 우선 수행 내역을 'PENDING' 상태로 DB에 저장합니다.
         MissionPerformance performance = MissionPerformance.builder()
                 .mission(mission)
                 .child(child)
-                .status(status)
-                .reason(aiResponse.reason())
+                .status(MissionStatus.PENDING) // 무조건 대기 상태로 시작!
+                .reason("AI가 사진을 분석하고 있습니다.")
                 .build();
-        //사진 URL은 나중에 S3 같은 곳에 올리고 URL을 받아 넣어야 함
+        performanceRepository.save(performance);
+
+        // try-catch 블록 내부와 외부 모두에서 사용하기 위해 변수를 미리 선언합니다.
+        AiVerificationResponse aiResponse;
+
+        try {
+            // 구글 Gemini AI 멀티모달 판독 요청
+            aiResponse = aiService.verifyMissionImage(image, category, prompt);
+
+            // AI 판독 성공 시 결과 결정 (ACCEPTED 또는 REJECTED)
+            MissionStatus finalStatus = aiResponse.isAccepted() ? MissionStatus.ACCEPTED : MissionStatus.REJECTED;
+
+            // 아까 저장해둔 performance 엔티티의 상태를 최종 판정 상태로 업데이트 (변경 감지 반영)
+            performance.updateStatusAndReason(finalStatus, aiResponse.reason());
+
+            // 미션 판독 결과가 성공(ACCEPTED)일 때만 실시간 보상 시간 정산 진행
+            if (finalStatus == MissionStatus.ACCEPTED) {
+                // 해당 미션에 걸려있는 보상 시간(reward) 가져오기
+                MissionSetting setting = missionSettingRepository.findByMissionId(missionId)
+                        .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
+                int rewardTime = setting.getReward();
+
+                // 현재 날짜 기준 년월 구하기 (예: "2026-05")
+                String currentYearMonth = YearMonth.now().toString();
+
+                // 자녀의 이번 달 시간 정책 정책판 가져오기
+                TimePolicy timePolicy = timePolicyRepository.findByChildIdAndYearMonth(childId, currentYearMonth)
+                        .orElseThrow(() -> new IllegalArgumentException("이번 달에 설정된 자녀의 시간 정책(TimePolicy)이 없습니다."));
+
+                // 시간 추가 정책 반영 (엔티티 내부 비즈니스 메서드 호출)
+                timePolicy.addReward(rewardTime);
+
+                // @Transactional 환경이므로 자동 반영되지만 가독성을 위해 호출 유지
+                timePolicyRepository.save(timePolicy);
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            // [AI 예외 처리] 구글 AI 서버 오류나 네트워크 장애 발생 시 Failsafe 우회
+            // DB에는 2번 단계에서 넣은 PENDING 데이터가 그대로 안전하게 유지
+            aiResponse = new AiVerificationResponse(false, "AI 서버 일시 오류로 인해 부모님 확인 대기 상태로 전환되었습니다.");
+            performance.updateStatusAndReason(MissionStatus.PENDING, aiResponse.reason());
+        }
 
         //최종적으로 DB에 영속화 (Save)
         performanceRepository.save(performance);

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPromptProvider.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPromptProvider.java
@@ -1,0 +1,27 @@
+package me.sogom.bridge.domain.mission.service;
+
+import me.sogom.bridge.domain.mission.entity.MissionCategory;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class MissionPromptProvider {
+
+    // 카테고리별 맞춤형 검증 프롬프트 맵핑
+    private static final Map<MissionCategory, String> PROMPTS = Map.of(
+            MissionCategory.CLEANING, "사진에 쓰레기가 없고, 물건들이 정돈되어 있으며, 청소가 완료된 깨끗한 공간인지 분석해 줘.",
+            MissionCategory.STUDY, "사진에 펼쳐진 책, 필기구, 노트 등 공부를 한 명확한 증거가 있는지 분석해 줘. 덜 풀린 문제가 있는 경우엔 fail 처리 해줘",
+            MissionCategory.EXERCISE, "사진에 헬스장, 운동 기구, 혹은 운동복을 입고 운동 중인 모습 등 명확한 증거가 있는지 분석해 줘. 등장하는 인물이 있다면 운동을 한 모습인지 분석해줘",
+            MissionCategory.READING, "사진에 글자가 선명하게 보이는 펼쳐진 책 페이지나 독서 중인 모습, 또는 독후감이 포함되어 있는지 분석해 줘. 독후감이라면 독후감의 내용이 너무 짧지 않은지 파악해줘",
+            MissionCategory.ETC, "주어진 사진이 특정 미션을 성공적으로 완수한 모습인지 일반적인 기준으로 분석해 줘."
+    );
+
+    public String getPrompt(MissionCategory category) {
+        // 카테고리가 null이거나 목록에 없으면 ETC(기타) 프롬프트를 기본으로 반환
+        if (category == null || !PROMPTS.containsKey(category)) {
+            return PROMPTS.get(MissionCategory.ETC);
+        }
+        return PROMPTS.get(category);
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionVerificationAiService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionVerificationAiService.java
@@ -1,6 +1,7 @@
 package me.sogom.bridge.domain.mission.service;
 
 import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
+import me.sogom.bridge.domain.mission.entity.MissionCategory;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.stereotype.Service;
@@ -13,22 +14,34 @@ import java.io.IOException;
 public class MissionVerificationAiService {
 
     private final ChatClient chatClient;
+    private final MissionPromptProvider promptProvider; //프롬프트 제공자 추가
 
-    public MissionVerificationAiService(ChatClient.Builder builder) {
+    //생성자를 통해 PromptProvider 주입
+    public MissionVerificationAiService(ChatClient.Builder builder, MissionPromptProvider promptProvider) {
         this.chatClient = builder.build();
+        this.promptProvider = promptProvider;
     }
 
-    public AiVerificationResponse verifyMissionImage(MultipartFile imageFile, String parentPrompt) throws IOException {
+    //파라미터에 'MissionCategory category' 추가
+    public AiVerificationResponse verifyMissionImage(MultipartFile imageFile, MissionCategory category, String parentPrompt) throws IOException {
 
         // 람다식(u -> u) 안으로 들어가기 전에 미리 getBytes()를 실행
         // 여기서 발생하는 에러는 메서드에 붙은 throws IOException이 처리
         byte[] imageBytes = imageFile.getBytes();
 
-        // 역할과 규칙을 보다 엄격하게 부여
+        //카테고리에 맞는 AI 판독 기준 가져오기
+        String categoryPrompt = promptProvider.getPrompt(category);
 
-        String systemInstruction = """
+        //부모님이 직접 작성한 요구사항이 있다면 합치기 (없으면 카테고리 기본값만 사용)
+        String finalCondition = (parentPrompt != null && !parentPrompt.isBlank())
+                ? "부모님 특별 요청: [" + parentPrompt + "]\n기본 검증 기준: [" + categoryPrompt + "]"
+                : "기본 검증 기준: [" + categoryPrompt + "]";
+
+        // String.format을 이용해 %s 자리에 finalCondition 주입
+        String systemInstruction = String.format("""
     당신은 학생들의 올바른 습관 형성을 돕는 전문적이고 이성적인 'AI 학습 멘토'입니다.
-    부모님이 설정한 미션 통과 기준은 다음과 같습니다: [%s]
+    이번 미션의 통과 기준은 다음과 같습니다:
+    %s
     
     [평가 원칙: 융통성과 변별력의 조화]
     1. 객관적 기준 적용: 미션의 핵심 요소가 누락되었다면 냉정하게 거절(false)하세요. 
@@ -48,7 +61,7 @@ public class MissionVerificationAiService {
     반드시 JSON 형식으로 응답하세요.
     - isAccepted: (true/false)
     - reason: (논리적이고 성숙한 피드백 메시지)
-    """.formatted(parentPrompt);
+    """, finalCondition); // 여기에 주입
 
         return chatClient.prompt()
                 .user(u -> u


### PR DESCRIPTION
## 개요
자녀가 수행한 미션이 AI에 의해 최종 승인(ACCEPTED)되었을 때 부모가 설정한 보상 시간(reward)이 자녀의 월간 시간 정책 정책판(time_policy)에 실시간으로 적립되는 기능을 구현

미션 제출 생명주기 안정성을 확보하기 위해 예외 처리 전략 및 정산 관련 비즈니스 가드 로직 업데이트

## 작업 내용
1. 실시간 보상 시간 정산 시스템 구축
- [x] MissionSettingRepository와 TimePolicyRepository를 주입받아 미션에 지정된 reward 분을 추출하는 로직을 추가

- [x] TimePolicy 엔티티 내부에 객체지향적 비즈니스 메서드인 addReward(int rewardTime)를 설계하여 가독성과 캡슐화를 높임

- [x] @Transactional 어노테이션 범주 내에서 변경 감지(Dirty Checking)가 정상 작동하도록 영속성 컨텍스트 흐름을 조율했습니다.

2. 예외 안전망(Failsafe) 아키텍처 - PENDING 처리
- [x] 사진 제출 시 무조건 AI를 먼저 찌르던 기존 방식을 탈환하여, 제출 즉시 우선 PENDING(대기) 상태로 먼저 DB에 안전하게 영속화하도록 순서를 최적화

- [x] 구글 Gemini API 통신 장애, 호출 리미트 초과 등 예기치 못한 인프라 예외가 발생할 경우 try-catch 블록이 이를 안전하게 잡아채어 부모의 수동 확인을 유도하는 대기 상태가 그대로 유지되도록 우회 처리

3. 중복 제출 차단 가드(Guard) 로직 설계
- [x] 이미 승인 완료(ACCEPTED)된 미션 ID로 자녀가 중복 요청을 보내 어뷰징하는 행위를 막기 위해, 최상단에서 최근 이력을 교차 매핑하는 방어 코드를 구현

- [x] MissionPerformanceRepository에 findTopByMissionIdOrderByIdDesc 쿼리 메서드를 커스텀 선언

- [x] MissionErrorCode ENUM에 MISSION_ALREADY_COMPLETED(400 Bad Request, "이미 완료된 미션입니다.") 규격을 신규 등록

## 테스트 결과 및 DB 교차 검증
- [x] 정상 흐름: 포스트맨 미션 수행 API 요청 ->  Gemini AI 사진 분석 성공 및 ACCEPTED 판정 ->  time_policy 테이블의 accumulated_reward_time 컬럼 수치가 실시간 가산(0 -> 30)됨을 SQL 교차 확인 완료.

- [x] 예외 흐름 (중복 제출 방지): 정산이 완료된 미션 ID로 포스트맨 재요청 시, AI 서버로 통신이 넘어가기 전 가드에 걸려 MISSION_ALREADY_COMPLETED (이미 완료된 미션입니다) 400 에러 응답을 반환하는 것 확인 완료.

## 관련 이슈사항
- Closes https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/26
- Relates to https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/26