### PR TITLE
Feat: 주간 및 일일 시간표(Schedule) 관리 기능 구현

### DIFF
--- a/src/main/java/me/sogom/bridge/domain/member/service/ParentService.java
+++ b/src/main/java/me/sogom/bridge/domain/member/service/ParentService.java
@@ -46,7 +46,7 @@ public class ParentService {
 
         // 자녀 정보 업데이트
         children.setParent(parent);
-        children.setBirth(request.birth());
+        children.setBirth(request.childrenBirth());
         children.setProfileImageUrl(request.profileImageUrl());
 
         childrenRepository.save(children);

--- a/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
@@ -2,6 +2,7 @@ package me.sogom.bridge.domain.mission.controller;
 
 import lombok.RequiredArgsConstructor;
 import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
+import me.sogom.bridge.domain.mission.entity.MissionCategory;
 import me.sogom.bridge.domain.mission.service.MissionPerformanceService; // 변경: 통합 서비스 임포트
 import me.sogom.bridge.global.apiPayload.ApiResponse;
 import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
@@ -25,11 +26,11 @@ public class MissionController {
             @PathVariable("missionId") Long missionId,      // 어떤 미션인지 (경로 변수)
             @RequestParam("childId") Long childId,          // 수행하는 자녀가 누구인지
             @RequestParam("image") MultipartFile image,     // 인증 사진
+            @RequestParam("category") MissionCategory category, //카테고리
             @RequestParam("prompt") String prompt) throws IOException {
 
         // Service에서 권한 검증 -> AI 판독 -> DB 저장(reason 포함)을 한 번에 처리 후 결과 반환
-        AiVerificationResponse result = performanceService.verifyAndSaveMission(missionId, childId, image, prompt);
-        
+        AiVerificationResponse result = performanceService.verifyAndSaveMission(missionId, childId, image, prompt, category);
         // APIResponse 포맷으로 반환
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, result);
     }

--- a/src/main/java/me/sogom/bridge/domain/mission/entity/MissionPerformance.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/entity/MissionPerformance.java
@@ -33,4 +33,10 @@ public class MissionPerformance extends BaseEntity {
 
     @Column(name = "reason", columnDefinition = "TEXT") //AI의 분석 근거를 저장할 컬럼 추가
     private String reason;
+
+    // AI 판독 결과나 부모 수동 확인에 의해 상태와 판독 이유를 변경하는 비즈니스 메서드
+    public void updateStatusAndReason(MissionStatus status, String reason) {
+        this.status = status;
+        this.reason = reason;
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/exception/MissionErrorCode.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/exception/MissionErrorCode.java
@@ -11,7 +11,8 @@ public enum MissionErrorCode implements BaseErrorCode {
 
     MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION404", "해당 미션을 찾을 수 없습니다."),
     AI_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MISSION500", "AI 판독 결과를 처리하는 중 오류가 발생했습니다."),
-    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "MISSION403", "해당 미션에 대한 수행 권한이 없습니다."); //권한 검증 실패 시 사용
+    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "MISSION403", "해당 미션에 대한 수행 권한이 없습니다."), //권한 검증 실패 시 사용
+    MISSION_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "MISSION400", "이미 완료된 미션입니다.");
     // 필요할 때마다 여기에 추가 예정
 
     private final HttpStatus status;

--- a/src/main/java/me/sogom/bridge/domain/mission/repository/MissionPerformanceRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/repository/MissionPerformanceRepository.java
@@ -3,6 +3,10 @@ package me.sogom.bridge.domain.mission.repository;
 import me.sogom.bridge.domain.mission.entity.MissionPerformance;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 // DB에 접근하여 저장/조회를 담당
 public interface MissionPerformanceRepository extends JpaRepository<MissionPerformance, Long> {
+    //미션 ID로 조회하여 가장 최근에 등록된 내역 1건만 가져오는 메서드
+    Optional<MissionPerformance> findTopByMissionIdOrderByIdDesc(Long missionId);
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/repository/MissionSettingRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/repository/MissionSettingRepository.java
@@ -1,0 +1,10 @@
+package me.sogom.bridge.domain.mission.repository;
+
+import me.sogom.bridge.domain.mission.entity.MissionSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface MissionSettingRepository extends JpaRepository<MissionSetting, String> {
+    // 미션 ID로 세팅 정보(reward가 포함된)를 조회하는 메서드
+    Optional<MissionSetting> findByMissionId(Long missionId);
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
@@ -5,6 +5,7 @@ import me.sogom.bridge.domain.member.entity.Children;
 import me.sogom.bridge.domain.member.repository.ChildrenRepository;
 import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
 import me.sogom.bridge.domain.mission.entity.Mission;
+import me.sogom.bridge.domain.mission.entity.MissionCategory;
 import me.sogom.bridge.domain.mission.entity.MissionPerformance;
 import me.sogom.bridge.domain.mission.entity.MissionStatus;
 import me.sogom.bridge.domain.mission.exception.MissionErrorCode;
@@ -27,8 +28,7 @@ public class MissionPerformanceService {
     private final MissionVerificationAiService aiService;
 
     @Transactional // 데이터를 DB에 반영하기 위해 반드시 필요
-    public AiVerificationResponse verifyAndSaveMission(Long missionId, Long childId, MultipartFile image, String prompt) throws IOException {
-
+    public AiVerificationResponse verifyAndSaveMission(Long missionId, Long childId, MultipartFile image, String prompt, MissionCategory category) throws IOException {
         //미션과 자녀 정보 조회 (예외 던지기 적용)
         Mission mission = missionRepository.findById(missionId)
                 .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
@@ -42,7 +42,7 @@ public class MissionPerformanceService {
         }
 
         //AI 판독 요청 (기존 MissionVerificationAiService 호출)
-        AiVerificationResponse aiResponse = aiService.verifyMissionImage(image, prompt);
+        AiVerificationResponse aiResponse = aiService.verifyMissionImage(image, category, prompt);
 
         //(Builder 패턴을 사용해서 객체 조립 (아직 이미지 X)
         MissionPerformance performance = MissionPerformance.builder()

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
@@ -4,19 +4,20 @@ import lombok.RequiredArgsConstructor;
 import me.sogom.bridge.domain.member.entity.Children;
 import me.sogom.bridge.domain.member.repository.ChildrenRepository;
 import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
-import me.sogom.bridge.domain.mission.entity.Mission;
-import me.sogom.bridge.domain.mission.entity.MissionCategory;
-import me.sogom.bridge.domain.mission.entity.MissionPerformance;
-import me.sogom.bridge.domain.mission.entity.MissionStatus;
+import me.sogom.bridge.domain.mission.entity.*;
 import me.sogom.bridge.domain.mission.exception.MissionErrorCode;
 import me.sogom.bridge.domain.mission.exception.MissionException;
 import me.sogom.bridge.domain.mission.repository.MissionPerformanceRepository;
 import me.sogom.bridge.domain.mission.repository.MissionRepository;
+import me.sogom.bridge.domain.mission.repository.MissionSettingRepository;
+import me.sogom.bridge.domain.policy.entity.TimePolicy;
+import me.sogom.bridge.domain.policy.repository.TimePolicyRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.YearMonth;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +27,8 @@ public class MissionPerformanceService {
     private final MissionRepository missionRepository;
     private final ChildrenRepository childrenRepository; // 자녀 조회
     private final MissionVerificationAiService aiService;
+    private final MissionSettingRepository missionSettingRepository;
+    private final TimePolicyRepository timePolicyRepository;
 
     @Transactional // 데이터를 DB에 반영하기 위해 반드시 필요
     public AiVerificationResponse verifyAndSaveMission(Long missionId, Long childId, MultipartFile image, String prompt, MissionCategory category) throws IOException {
@@ -44,11 +47,35 @@ public class MissionPerformanceService {
         //AI 판독 요청 (기존 MissionVerificationAiService 호출)
         AiVerificationResponse aiResponse = aiService.verifyMissionImage(image, category, prompt);
 
-        //(Builder 패턴을 사용해서 객체 조립 (아직 이미지 X)
+        // 결과에 따른 미션 상태 결정
+        MissionStatus status = aiResponse.isAccepted() ? MissionStatus.ACCEPTED : MissionStatus.REJECTED;
+
+        // 미션 판독 결과가 성공(ACCEPTED)일 때만 실시간 보상 시간 정산 진행
+        if (status == MissionStatus.ACCEPTED) {
+            // 해당 미션에 걸려있는 보상 시간(reward) 가져오기
+            MissionSetting setting = missionSettingRepository.findByMissionId(missionId)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
+            int rewardTime = setting.getReward();
+
+            // 현재 날짜 기준 년월 구하기 (예: "2026-05")
+            String currentYearMonth = YearMonth.now().toString();
+
+            // 자녀의 이번 달 시간 정책 가져와서 보상 시간 누적하기
+            TimePolicy timePolicy = timePolicyRepository.findByChildIdAndYearMonth(childId, currentYearMonth)
+                    .orElseThrow(() -> new IllegalArgumentException("이번 달에 설정된 자녀의 시간 정책(TimePolicy)이 없습니다."));
+
+            // 시간 추가 (엔티티 내부 메서드 호출)
+            timePolicy.addReward(rewardTime);
+
+            // @Transactional 환경이므로 Dirty Checking(변경 감지)이 일어나 자동 저장되지만, 명시적인 가독성을 위해 호출
+            timePolicyRepository.save(timePolicy);
+        }
+
+        // 객체 조립 및 수행 내역 저장
         MissionPerformance performance = MissionPerformance.builder()
                 .mission(mission)
                 .child(child)
-                .status(aiResponse.isAccepted() ? MissionStatus.ACCEPTED : MissionStatus.REJECTED)
+                .status(status)
                 .reason(aiResponse.reason())
                 .build();
         //사진 URL은 나중에 S3 같은 곳에 올리고 URL을 받아 넣어야 함

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
@@ -44,41 +44,66 @@ public class MissionPerformanceService {
             throw new MissionException(MissionErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        //AI 판독 요청 (기존 MissionVerificationAiService 호출)
-        AiVerificationResponse aiResponse = aiService.verifyMissionImage(image, category, prompt);
+        //해당 미션의 가장 최근 수행 내역을 확인합니다.
+        performanceRepository.findTopByMissionIdOrderByIdDesc(missionId)
+                .ifPresent(lastPerformance -> {
+                    // 이미 부모나 AI가 승인(ACCEPTED)한 미션이라면 더 이상 진행하지 못하게 차단!
+                    if (lastPerformance.getStatus() == MissionStatus.ACCEPTED) {
+                        throw new MissionException(MissionErrorCode.MISSION_ALREADY_COMPLETED);
+                        // ➡️ 익셉션 핸들러를 통해 포스트맨에 "이미 완료된 미션입니다" (400) 에러가 예쁘게 나감
+                    }
+                });
 
-        // 결과에 따른 미션 상태 결정
-        MissionStatus status = aiResponse.isAccepted() ? MissionStatus.ACCEPTED : MissionStatus.REJECTED;
-
-        // 미션 판독 결과가 성공(ACCEPTED)일 때만 실시간 보상 시간 정산 진행
-        if (status == MissionStatus.ACCEPTED) {
-            // 해당 미션에 걸려있는 보상 시간(reward) 가져오기
-            MissionSetting setting = missionSettingRepository.findByMissionId(missionId)
-                    .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
-            int rewardTime = setting.getReward();
-
-            // 현재 날짜 기준 년월 구하기 (예: "2026-05")
-            String currentYearMonth = YearMonth.now().toString();
-
-            // 자녀의 이번 달 시간 정책 가져와서 보상 시간 누적하기
-            TimePolicy timePolicy = timePolicyRepository.findByChildIdAndYearMonth(childId, currentYearMonth)
-                    .orElseThrow(() -> new IllegalArgumentException("이번 달에 설정된 자녀의 시간 정책(TimePolicy)이 없습니다."));
-
-            // 시간 추가 (엔티티 내부 메서드 호출)
-            timePolicy.addReward(rewardTime);
-
-            // @Transactional 환경이므로 Dirty Checking(변경 감지)이 일어나 자동 저장되지만, 명시적인 가독성을 위해 호출
-            timePolicyRepository.save(timePolicy);
-        }
-
-        // 객체 조립 및 수행 내역 저장
+        // 2. [PENDING 먼저 저장] AI를 호출하기 전에 우선 수행 내역을 'PENDING' 상태로 DB에 저장합니다.
         MissionPerformance performance = MissionPerformance.builder()
                 .mission(mission)
                 .child(child)
-                .status(status)
-                .reason(aiResponse.reason())
+                .status(MissionStatus.PENDING) // 무조건 대기 상태로 시작!
+                .reason("AI가 사진을 분석하고 있습니다.")
                 .build();
-        //사진 URL은 나중에 S3 같은 곳에 올리고 URL을 받아 넣어야 함
+        performanceRepository.save(performance);
+
+        // try-catch 블록 내부와 외부 모두에서 사용하기 위해 변수를 미리 선언합니다.
+        AiVerificationResponse aiResponse;
+
+        try {
+            // 구글 Gemini AI 멀티모달 판독 요청
+            aiResponse = aiService.verifyMissionImage(image, category, prompt);
+
+            // AI 판독 성공 시 결과 결정 (ACCEPTED 또는 REJECTED)
+            MissionStatus finalStatus = aiResponse.isAccepted() ? MissionStatus.ACCEPTED : MissionStatus.REJECTED;
+
+            // 아까 저장해둔 performance 엔티티의 상태를 최종 판정 상태로 업데이트 (변경 감지 반영)
+            performance.updateStatusAndReason(finalStatus, aiResponse.reason());
+
+            // 미션 판독 결과가 성공(ACCEPTED)일 때만 실시간 보상 시간 정산 진행
+            if (finalStatus == MissionStatus.ACCEPTED) {
+                // 해당 미션에 걸려있는 보상 시간(reward) 가져오기
+                MissionSetting setting = missionSettingRepository.findByMissionId(missionId)
+                        .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
+                int rewardTime = setting.getReward();
+
+                // 현재 날짜 기준 년월 구하기 (예: "2026-05")
+                String currentYearMonth = YearMonth.now().toString();
+
+                // 자녀의 이번 달 시간 정책 정책판 가져오기
+                TimePolicy timePolicy = timePolicyRepository.findByChildIdAndYearMonth(childId, currentYearMonth)
+                        .orElseThrow(() -> new IllegalArgumentException("이번 달에 설정된 자녀의 시간 정책(TimePolicy)이 없습니다."));
+
+                // 시간 추가 정책 반영 (엔티티 내부 비즈니스 메서드 호출)
+                timePolicy.addReward(rewardTime);
+
+                // @Transactional 환경이므로 자동 반영되지만 가독성을 위해 호출 유지
+                timePolicyRepository.save(timePolicy);
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            // [AI 예외 처리] 구글 AI 서버 오류나 네트워크 장애 발생 시 Failsafe 우회
+            // DB에는 2번 단계에서 넣은 PENDING 데이터가 그대로 안전하게 유지
+            aiResponse = new AiVerificationResponse(false, "AI 서버 일시 오류로 인해 부모님 확인 대기 상태로 전환되었습니다.");
+            performance.updateStatusAndReason(MissionStatus.PENDING, aiResponse.reason());
+        }
 
         //최종적으로 DB에 영속화 (Save)
         performanceRepository.save(performance);

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPromptProvider.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPromptProvider.java
@@ -1,0 +1,27 @@
+package me.sogom.bridge.domain.mission.service;
+
+import me.sogom.bridge.domain.mission.entity.MissionCategory;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class MissionPromptProvider {
+
+    // 카테고리별 맞춤형 검증 프롬프트 맵핑
+    private static final Map<MissionCategory, String> PROMPTS = Map.of(
+            MissionCategory.CLEANING, "사진에 쓰레기가 없고, 물건들이 정돈되어 있으며, 청소가 완료된 깨끗한 공간인지 분석해 줘.",
+            MissionCategory.STUDY, "사진에 펼쳐진 책, 필기구, 노트 등 공부를 한 명확한 증거가 있는지 분석해 줘. 덜 풀린 문제가 있는 경우엔 fail 처리 해줘",
+            MissionCategory.EXERCISE, "사진에 헬스장, 운동 기구, 혹은 운동복을 입고 운동 중인 모습 등 명확한 증거가 있는지 분석해 줘. 등장하는 인물이 있다면 운동을 한 모습인지 분석해줘",
+            MissionCategory.READING, "사진에 글자가 선명하게 보이는 펼쳐진 책 페이지나 독서 중인 모습, 또는 독후감이 포함되어 있는지 분석해 줘. 독후감이라면 독후감의 내용이 너무 짧지 않은지 파악해줘",
+            MissionCategory.ETC, "주어진 사진이 특정 미션을 성공적으로 완수한 모습인지 일반적인 기준으로 분석해 줘."
+    );
+
+    public String getPrompt(MissionCategory category) {
+        // 카테고리가 null이거나 목록에 없으면 ETC(기타) 프롬프트를 기본으로 반환
+        if (category == null || !PROMPTS.containsKey(category)) {
+            return PROMPTS.get(MissionCategory.ETC);
+        }
+        return PROMPTS.get(category);
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionVerificationAiService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionVerificationAiService.java
@@ -1,6 +1,7 @@
 package me.sogom.bridge.domain.mission.service;
 
 import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
+import me.sogom.bridge.domain.mission.entity.MissionCategory;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.stereotype.Service;
@@ -13,22 +14,34 @@ import java.io.IOException;
 public class MissionVerificationAiService {
 
     private final ChatClient chatClient;
+    private final MissionPromptProvider promptProvider; //프롬프트 제공자 추가
 
-    public MissionVerificationAiService(ChatClient.Builder builder) {
+    //생성자를 통해 PromptProvider 주입
+    public MissionVerificationAiService(ChatClient.Builder builder, MissionPromptProvider promptProvider) {
         this.chatClient = builder.build();
+        this.promptProvider = promptProvider;
     }
 
-    public AiVerificationResponse verifyMissionImage(MultipartFile imageFile, String parentPrompt) throws IOException {
+    //파라미터에 'MissionCategory category' 추가
+    public AiVerificationResponse verifyMissionImage(MultipartFile imageFile, MissionCategory category, String parentPrompt) throws IOException {
 
         // 람다식(u -> u) 안으로 들어가기 전에 미리 getBytes()를 실행
         // 여기서 발생하는 에러는 메서드에 붙은 throws IOException이 처리
         byte[] imageBytes = imageFile.getBytes();
 
-        // 역할과 규칙을 보다 엄격하게 부여
+        //카테고리에 맞는 AI 판독 기준 가져오기
+        String categoryPrompt = promptProvider.getPrompt(category);
 
-        String systemInstruction = """
+        //부모님이 직접 작성한 요구사항이 있다면 합치기 (없으면 카테고리 기본값만 사용)
+        String finalCondition = (parentPrompt != null && !parentPrompt.isBlank())
+                ? "부모님 특별 요청: [" + parentPrompt + "]\n기본 검증 기준: [" + categoryPrompt + "]"
+                : "기본 검증 기준: [" + categoryPrompt + "]";
+
+        // String.format을 이용해 %s 자리에 finalCondition 주입
+        String systemInstruction = String.format("""
     당신은 학생들의 올바른 습관 형성을 돕는 전문적이고 이성적인 'AI 학습 멘토'입니다.
-    부모님이 설정한 미션 통과 기준은 다음과 같습니다: [%s]
+    이번 미션의 통과 기준은 다음과 같습니다:
+    %s
     
     [평가 원칙: 융통성과 변별력의 조화]
     1. 객관적 기준 적용: 미션의 핵심 요소가 누락되었다면 냉정하게 거절(false)하세요. 
@@ -48,7 +61,7 @@ public class MissionVerificationAiService {
     반드시 JSON 형식으로 응답하세요.
     - isAccepted: (true/false)
     - reason: (논리적이고 성숙한 피드백 메시지)
-    """.formatted(parentPrompt);
+    """, finalCondition); // 여기에 주입
 
         return chatClient.prompt()
                 .user(u -> u

--- a/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
@@ -46,4 +46,26 @@ public class TimePolicy extends BaseEntity {
     }
 
     public void updateBaseTime(int baseTime) { this.baseTime = baseTime; }
+
+    //기본 제공 시간과 보상 시간을 합쳐서 연장할 시간을 차감 (기본 시간에서 먼저 차감하고, 부족하면 보상 시간에서 차감)
+
+    public void deductAvailableTime(int minutes) {
+        int totalAvailable = this.baseTime + this.accumulatedRewardTime;
+
+        // 전체 가용 시간(기본+보상)이 연장하려는 시간보다 적은지 검문
+        if (totalAvailable < minutes) {
+            throw new IllegalArgumentException("사용 가능한 총 시간(기본+보상)이 부족하여 연장할 수 없습니다.");
+        }
+
+        // 기본 시간이 충분히 남아있다면 기본 시간에서만 차감
+        if (this.baseTime >= minutes) {
+            this.baseTime -= minutes;
+        }
+        // 기본 시간이 모자라다면, 기본 시간을 0으로 만들고 남은 만큼을 보상 시간에서 차감
+        else {
+            int remainder = minutes - this.baseTime;
+            this.baseTime = 0;
+            this.accumulatedRewardTime -= remainder;
+        }
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
@@ -68,4 +68,11 @@ public class TimePolicy extends BaseEntity {
             this.accumulatedRewardTime -= remainder;
         }
     }
+    //자녀가 당일에 쓰지 않고 남긴 시간을 보상 시간 풀로 다시 환불(적립)해주는 메서드
+    public void refundUnusedTime(int unusedMinutes) {
+        if (unusedMinutes < 0) {
+            throw new IllegalArgumentException("적립할 시간은 음수일 수 없습니다.");
+        }
+        this.accumulatedRewardTime += unusedMinutes;
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
@@ -86,4 +86,16 @@ public class ScheduleController {
         scheduleService.deleteRoutine(routineId);
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, "일정이 삭제되었습니다.");
     }
+    //[POST] 자녀의 당일 가용 시간 최종 정산 및 잔여 시간 보상 풀 환불
+    // URL 예시: POST /api/v1/children/1/schedules/settle?actualUsed=100
+    @PostMapping("/settle")
+    public ApiResponse<DailyScheduleResponse> settleDailyTime(
+            @PathVariable Long childId,
+            @RequestParam int actualUsed,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+
+        DailyTimeAllocation settledAllocation = scheduleService.settleDailyTime(childId, date, actualUsed);
+
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, DailyScheduleResponse.from(settledAllocation));
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
@@ -2,21 +2,15 @@ package me.sogom.bridge.domain.schedule.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import me.sogom.bridge.domain.schedule.dto.DailyScheduleResponse;
-import me.sogom.bridge.domain.schedule.dto.RoutineRequest;
-import me.sogom.bridge.domain.schedule.dto.TimeExtensionRequest;
-import me.sogom.bridge.domain.schedule.dto.WeeklyTemplateRequest;
+import me.sogom.bridge.domain.schedule.dto.*;
 import me.sogom.bridge.domain.schedule.entity.DailyTimeAllocation;
 import me.sogom.bridge.domain.schedule.entity.WeeklyRoutine;
 import me.sogom.bridge.domain.schedule.service.ScheduleService;
 import me.sogom.bridge.global.apiPayload.ApiResponse;
 import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
-
-// 시큐리티 및 인증 객체 임포트
 import me.sogom.bridge.global.security.entity.AuthMember;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -91,14 +85,20 @@ public class ScheduleController {
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, "고정 일정이 성공적으로 등록되었습니다.");
     }
 
-    //[GET] 자녀의 주간 학원/고정 일정 전체 조회
+    //[GET] 자녀의 주간 학원/고정 일정 전체 조회 (DTO 필터 적용 버전!)
     @GetMapping("/routines")
-    public ApiResponse<List<WeeklyRoutine>> getWeeklyRoutines(
+    public ApiResponse<List<RoutineResponse>> getWeeklyRoutines(
             @AuthenticationPrincipal AuthMember user) {
 
         Long childId = user.asChildren().getId();
         List<WeeklyRoutine> routines = scheduleService.getWeeklyRoutines(childId);
-        return ApiResponse.onSuccess(GeneralSuccessCode.OK, routines);
+
+        // 🌟 거대했던 엔티티 뭉치들을 깔끔한 RoutineResponse DTO 리스트로 변환합니다.
+        List<RoutineResponse> response = routines.stream()
+                .map(RoutineResponse::from)
+                .toList();
+
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, response);
     }
 
     //[DELETE] 학원 고정 일정 삭제

--- a/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
@@ -11,6 +11,11 @@ import me.sogom.bridge.domain.schedule.entity.WeeklyRoutine;
 import me.sogom.bridge.domain.schedule.service.ScheduleService;
 import me.sogom.bridge.global.apiPayload.ApiResponse;
 import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
+
+// 시큐리티 및 인증 객체 임포트
+import me.sogom.bridge.global.security.entity.AuthMember;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,83 +24,89 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/children/{childId}/schedules")
+@RequestMapping("/api/v1/schedules")
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
 
-    //URL 예시: GET /api/v1/children/1/schedules/daily?date=2026-05-16
+    //[GET] 자녀의 특정 날짜 시간표 조회
     @GetMapping("/daily")
     public ApiResponse<DailyScheduleResponse> getDailySchedule(
-            @PathVariable Long childId,
+            @AuthenticationPrincipal AuthMember user,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
 
-        //서비스 비즈니스 로직 호출 (조회 혹은 자동 동적 생성)
+        //자녀 엔티티를 꺼낸 후 ID를 추출
+        Long childId = user.asChildren().getId();
         DailyTimeAllocation allocation = scheduleService.getOrCreateDailyAllocation(childId, date);
 
         //GeneralSuccessCode.OK에 응답 데이터를 저장 후 return
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, DailyScheduleResponse.from(allocation));
     }
 
-    //URL 예시: POST /api/v1/children/1/schedules/extend
+    //[POST] 자녀의 특정 날짜 시간 연장
     @PostMapping("/extend")
     public ApiResponse<DailyScheduleResponse> extendDailyTime(
-            @PathVariable Long childId,
+            @AuthenticationPrincipal AuthMember user,
             @Valid @RequestBody TimeExtensionRequest request) {
 
         //부모 보상 시간 차감 및 오늘 제한 시간 증가
+        Long childId = user.asChildren().getId();
         DailyTimeAllocation updatedAllocation = scheduleService.extendDailyTime(
-                childId,
-                request.getTargetDate(),
-                request.getExtraMinutes()
+                childId, request.getTargetDate(), request.getExtraMinutes()
         );
 
         //업데이트 완료된 데이터를 공통 규격에 맞춰 return
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, DailyScheduleResponse.from(updatedAllocation));
     }
-    //[PUT] 주간 요일별 가용시간 기본 틀(템플릿) 설정/수정
-    @PutMapping("/templates")
-    public ApiResponse<String> updateWeeklyTemplate(
-            @PathVariable Long childId,
-            @RequestBody WeeklyTemplateRequest request) {
-        scheduleService.updateWeeklyTemplate(childId, request);
-        return ApiResponse.onSuccess(GeneralSuccessCode.OK, "요일별 기본 가용 시간이 설정되었습니다.");
+
+    //[POST] 당일 사용 시간 최종 정산 및 잔여 시간 보상 풀 환불 마감
+    @PostMapping("/settle")
+    public ApiResponse<DailyScheduleResponse> settleDailyTime(
+            @AuthenticationPrincipal AuthMember user,
+            @RequestParam int actualUsed,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+
+        Long childId = user.asChildren().getId();
+        DailyTimeAllocation settledAllocation = scheduleService.settleDailyTime(childId, date, actualUsed);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, DailyScheduleResponse.from(settledAllocation));
     }
 
-    //[POST] 학원 고정 일정 등록
+    //[PUT] 주간 요일별 가용시간 기본 틀(템플릿) 설정 및 수정
+    @PutMapping("/templates")
+    public ApiResponse<String> updateWeeklyTemplate(
+            @AuthenticationPrincipal AuthMember user,
+            @RequestBody WeeklyTemplateRequest request) {
+        Long childId = user.asChildren().getId();
+        scheduleService.updateWeeklyTemplate(childId, request);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, "요일별 기본 가용 시간이 성공적으로 설정되었습니다.");
+    }
+
+    //[POST] 학원 고정 일정(Routine) 등록
     @PostMapping("/routines")
     public ApiResponse<String> createRoutine(
-            @PathVariable Long childId,
+            @AuthenticationPrincipal AuthMember user,
             @RequestBody RoutineRequest request) {
+        Long childId = user.asChildren().getId();
         scheduleService.createRoutine(childId, request);
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, "고정 일정이 성공적으로 등록되었습니다.");
     }
 
-    //[GET] 자녀의 주간 학원/고정 일정 전체 조회 (참고용 시간표 뷰에 그려짐)
+    //[GET] 자녀의 주간 학원/고정 일정 전체 조회
     @GetMapping("/routines")
-    public ApiResponse<List<WeeklyRoutine>> getWeeklyRoutines(@PathVariable Long childId) {
+    public ApiResponse<List<WeeklyRoutine>> getWeeklyRoutines(
+            @AuthenticationPrincipal AuthMember user) {
+
+        Long childId = user.asChildren().getId();
         List<WeeklyRoutine> routines = scheduleService.getWeeklyRoutines(childId);
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, routines);
     }
 
-    //[DELETE] 고정 일정 삭제
+    //[DELETE] 학원 고정 일정 삭제
     @DeleteMapping("/routines/{routineId}")
     public ApiResponse<String> deleteRoutine(
-            @PathVariable Long childId,
+            @AuthenticationPrincipal AuthMember user,
             @PathVariable Long routineId) {
         scheduleService.deleteRoutine(routineId);
-        return ApiResponse.onSuccess(GeneralSuccessCode.OK, "일정이 삭제되었습니다.");
-    }
-    //[POST] 자녀의 당일 가용 시간 최종 정산 및 잔여 시간 보상 풀 환불
-    // URL 예시: POST /api/v1/children/1/schedules/settle?actualUsed=100
-    @PostMapping("/settle")
-    public ApiResponse<DailyScheduleResponse> settleDailyTime(
-            @PathVariable Long childId,
-            @RequestParam int actualUsed,
-            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
-
-        DailyTimeAllocation settledAllocation = scheduleService.settleDailyTime(childId, date, actualUsed);
-
-        return ApiResponse.onSuccess(GeneralSuccessCode.OK, DailyScheduleResponse.from(settledAllocation));
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, "일정이 정상적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
@@ -1,0 +1,89 @@
+package me.sogom.bridge.domain.schedule.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import me.sogom.bridge.domain.schedule.dto.DailyScheduleResponse;
+import me.sogom.bridge.domain.schedule.dto.RoutineRequest;
+import me.sogom.bridge.domain.schedule.dto.TimeExtensionRequest;
+import me.sogom.bridge.domain.schedule.dto.WeeklyTemplateRequest;
+import me.sogom.bridge.domain.schedule.entity.DailyTimeAllocation;
+import me.sogom.bridge.domain.schedule.entity.WeeklyRoutine;
+import me.sogom.bridge.domain.schedule.service.ScheduleService;
+import me.sogom.bridge.global.apiPayload.ApiResponse;
+import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/children/{childId}/schedules")
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    //URL 예시: GET /api/v1/children/1/schedules/daily?date=2026-05-16
+    @GetMapping("/daily")
+    public ApiResponse<DailyScheduleResponse> getDailySchedule(
+            @PathVariable Long childId,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+
+        //서비스 비즈니스 로직 호출 (조회 혹은 자동 동적 생성)
+        DailyTimeAllocation allocation = scheduleService.getOrCreateDailyAllocation(childId, date);
+
+        //GeneralSuccessCode.OK에 응답 데이터를 저장 후 return
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, DailyScheduleResponse.from(allocation));
+    }
+
+    //URL 예시: POST /api/v1/children/1/schedules/extend
+    @PostMapping("/extend")
+    public ApiResponse<DailyScheduleResponse> extendDailyTime(
+            @PathVariable Long childId,
+            @Valid @RequestBody TimeExtensionRequest request) {
+
+        //부모 보상 시간 차감 및 오늘 제한 시간 증가
+        DailyTimeAllocation updatedAllocation = scheduleService.extendDailyTime(
+                childId,
+                request.getTargetDate(),
+                request.getExtraMinutes()
+        );
+
+        //업데이트 완료된 데이터를 공통 규격에 맞춰 return
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, DailyScheduleResponse.from(updatedAllocation));
+    }
+    //[PUT] 주간 요일별 가용시간 기본 틀(템플릿) 설정/수정
+    @PutMapping("/templates")
+    public ApiResponse<String> updateWeeklyTemplate(
+            @PathVariable Long childId,
+            @RequestBody WeeklyTemplateRequest request) {
+        scheduleService.updateWeeklyTemplate(childId, request);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, "요일별 기본 가용 시간이 설정되었습니다.");
+    }
+
+    //[POST] 학원 고정 일정 등록
+    @PostMapping("/routines")
+    public ApiResponse<String> createRoutine(
+            @PathVariable Long childId,
+            @RequestBody RoutineRequest request) {
+        scheduleService.createRoutine(childId, request);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, "고정 일정이 성공적으로 등록되었습니다.");
+    }
+
+    //[GET] 자녀의 주간 학원/고정 일정 전체 조회 (참고용 시간표 뷰에 그려짐)
+    @GetMapping("/routines")
+    public ApiResponse<List<WeeklyRoutine>> getWeeklyRoutines(@PathVariable Long childId) {
+        List<WeeklyRoutine> routines = scheduleService.getWeeklyRoutines(childId);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, routines);
+    }
+
+    //[DELETE] 고정 일정 삭제
+    @DeleteMapping("/routines/{routineId}")
+    public ApiResponse<String> deleteRoutine(
+            @PathVariable Long childId,
+            @PathVariable Long routineId) {
+        scheduleService.deleteRoutine(routineId);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, "일정이 삭제되었습니다.");
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/DailyScheduleResponse.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/DailyScheduleResponse.java
@@ -1,0 +1,28 @@
+package me.sogom.bridge.domain.schedule.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import me.sogom.bridge.domain.schedule.entity.DailyTimeAllocation;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class DailyScheduleResponse {
+    private Long id;
+    private LocalDate targetDate;
+    private int baseMinutes;
+    private int extendedMinutes;
+    private int totalAvailableMinutes;
+
+    // 엔티티를 DTO로 변환
+    public static DailyScheduleResponse from(DailyTimeAllocation allocation) {
+        return DailyScheduleResponse.builder()
+                .id(allocation.getId())
+                .targetDate(allocation.getTargetDate())
+                .baseMinutes(allocation.getBaseMinutes())
+                .extendedMinutes(allocation.getExtendedMinutes())
+                .totalAvailableMinutes(allocation.getTotalAvailableTime())
+                .build();
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/RoutineRequest.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/RoutineRequest.java
@@ -1,0 +1,13 @@
+//학원 일정 등록 요청 DTO
+package me.sogom.bridge.domain.schedule.dto;
+import lombok.Getter;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+@Getter
+public class RoutineRequest {
+    private DayOfWeek dayOfWeek;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private String title;
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/RoutineResponse.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/RoutineResponse.java
@@ -1,0 +1,30 @@
+package me.sogom.bridge.domain.schedule.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import me.sogom.bridge.domain.schedule.entity.WeeklyRoutine;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RoutineResponse {
+    private Long id;
+    private DayOfWeek dayOfWeek;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private String title;
+
+    // 엔티티를 안전하고 깔끔한 DTO로 변환해주는 메서드
+    public static RoutineResponse from(WeeklyRoutine routine) {
+        return RoutineResponse.builder()
+                .id(routine.getId())
+                .dayOfWeek(routine.getDayOfWeek())
+                .startTime(routine.getStartTime())
+                .endTime(routine.getEndTime())
+                .title(routine.getTitle())
+                .build();
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/TimeExtensionRequest.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/TimeExtensionRequest.java
@@ -1,0 +1,16 @@
+package me.sogom.bridge.domain.schedule.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class TimeExtensionRequest {
+    private LocalDate targetDate;
+
+    @Min(value = 1, message = "연장할 시간은 1분 이상이어야 합니다.")
+    private int extraMinutes;
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/WeeklyTemplateRequest.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/WeeklyTemplateRequest.java
@@ -1,0 +1,10 @@
+//요일별 기본 분배 시간 설정 요청 DTO
+package me.sogom.bridge.domain.schedule.dto;
+import lombok.Getter;
+import java.time.DayOfWeek;
+
+@Getter
+public class WeeklyTemplateRequest {
+    private DayOfWeek dayOfWeek;
+    private int baseMinutes;
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/entity/DailyTimeAllocation.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/entity/DailyTimeAllocation.java
@@ -1,0 +1,55 @@
+package me.sogom.bridge.domain.schedule.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.sogom.bridge.domain.common.BaseEntity;
+import me.sogom.bridge.domain.member.entity.Children;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@EnableJpaAuditing
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "daily_time_allocations")
+public class DailyTimeAllocation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "child_id", nullable = false)
+    private Children child;
+
+    @Column(name = "target_date", nullable = false)
+    private LocalDate targetDate; // 연장이 일어나는 구체적인 날짜 (예: 2026-05-16)
+
+    @Column(name = "base_minutes", nullable = false)
+    private int baseMinutes; // 그날 요일의 템플릿에서 복사해온 기본 시간
+
+    @Column(name = "extended_minutes", nullable = false)
+    private int extendedMinutes; // 자녀가 보상이나 여분으로 추가 연장한 시간
+
+    @Builder
+    public DailyTimeAllocation(Children child, LocalDate targetDate, int baseMinutes, int extendedMinutes) {
+        this.child = child;
+        this.targetDate = targetDate;
+        this.baseMinutes = baseMinutes;
+        this.extendedMinutes = extendedMinutes;
+    }
+
+    // 객체지향 비즈니스 메서드: 오늘의 시간 추가 연장
+    public void addExtraTime(int minutes) {
+        this.extendedMinutes += minutes;
+    }
+
+    // 최종 자녀 폰에 적용될 제한 시간 계산용 메서드
+    public int getTotalAvailableTime() {
+        return this.baseMinutes + this.extendedMinutes;
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/entity/DailyTimeAllocation.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/entity/DailyTimeAllocation.java
@@ -52,4 +52,10 @@ public class DailyTimeAllocation extends BaseEntity {
     public int getTotalAvailableTime() {
         return this.baseMinutes + this.extendedMinutes;
     }
+
+    //당일 사용 시간을 실제로 자녀가 사용한 시간으로 최종 정산
+    public void updateToSettledTime(int actualUsedMinutes) {
+        this.baseMinutes = actualUsedMinutes;
+        this.extendedMinutes = 0; // 정산이 끝났으므로 연장 시간 변수는 0으로 리셋
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/entity/WeeklyRoutine.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/entity/WeeklyRoutine.java
@@ -1,0 +1,57 @@
+package me.sogom.bridge.domain.schedule.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.sogom.bridge.domain.common.BaseEntity;
+import me.sogom.bridge.domain.member.entity.Children;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "weekly_routines")
+public class WeeklyRoutine extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "weekly_routine_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "children_id", nullable = false)
+    private Children child;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DayOfWeek dayOfWeek; // MONDAY, TUESDAY ...
+
+    @Column(nullable = false)
+    private LocalTime startTime; // 예: 16:00
+
+    @Column(nullable = false)
+    private LocalTime endTime; // 예: 18:00
+
+    @Column(nullable = false)
+    private String title; // 예: "영어학원"
+
+    @Builder
+    public WeeklyRoutine(Children child, DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime, String title) {
+        this.child = child;
+        this.dayOfWeek = dayOfWeek;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.title = title;
+    }
+
+    public void updateRoutine(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime, String title) {
+        this.dayOfWeek = dayOfWeek;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.title = title;
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/entity/WeeklyTimeDistribution.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/entity/WeeklyTimeDistribution.java
@@ -1,0 +1,47 @@
+package me.sogom.bridge.domain.schedule.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.sogom.bridge.domain.common.BaseEntity;
+import me.sogom.bridge.domain.member.entity.Children;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.time.DayOfWeek;
+
+@Entity
+@Getter
+@EnableJpaAuditing
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "weekly_time_distributions")
+public class WeeklyTimeDistribution extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Children Entity import
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "child_id", nullable = false)
+    private Children child;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day_of_week", nullable = false)
+    private DayOfWeek dayOfWeek; // MONDAY, TUESDAY ... SUNDAY
+
+    @Column(name = "base_minutes", nullable = false)
+    private int baseMinutes; // 요일별 기본 세팅 시간 (분 단위)
+
+    @Builder
+    public WeeklyTimeDistribution(Children child, DayOfWeek dayOfWeek, int baseMinutes) {
+        this.child = child;
+        this.dayOfWeek = dayOfWeek;
+        this.baseMinutes = baseMinutes;
+    }
+
+    public void updateBaseMinutes(int minutes) {
+        this.baseMinutes = minutes;
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/repository/DailyTimeAllocationRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/repository/DailyTimeAllocationRepository.java
@@ -1,0 +1,19 @@
+package me.sogom.bridge.domain.schedule.repository;
+
+import me.sogom.bridge.domain.schedule.entity.DailyTimeAllocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface DailyTimeAllocationRepository extends JpaRepository<DailyTimeAllocation, Long> {
+
+    // 특정 자녀의 '특정 날짜(오늘)' 데이터 단건 조회 (오늘 앱을 켤 때 가장 많이 쓰임!)
+    Optional<DailyTimeAllocation> findByChildIdAndTargetDate(Long childId, LocalDate targetDate);
+
+    // 특정 자녀의 '특정 기간(시작일~종료일)' 데이터 조회 (과거 사용 리포트나 주간 달력 뷰 그릴 때 유용)
+    List<DailyTimeAllocation> findAllByChildIdAndTargetDateBetween(Long childId, LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/repository/WeeklyRoutineRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/repository/WeeklyRoutineRepository.java
@@ -1,0 +1,10 @@
+package me.sogom.bridge.domain.schedule.repository;
+
+import me.sogom.bridge.domain.schedule.entity.WeeklyRoutine;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface WeeklyRoutineRepository extends JpaRepository<WeeklyRoutine, Long> {
+    // 특정 자녀의 일주일 전체 학원/고정 일정 조회
+    List<WeeklyRoutine> findAllByChild_Id(Long childId);
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/repository/WeeklyTimeDistributionRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/repository/WeeklyTimeDistributionRepository.java
@@ -1,0 +1,19 @@
+package me.sogom.bridge.domain.schedule.repository;
+
+import me.sogom.bridge.domain.schedule.entity.WeeklyTimeDistribution;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.DayOfWeek;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface WeeklyTimeDistributionRepository extends JpaRepository<WeeklyTimeDistribution, Long> {
+
+    // 특정 자녀의 '특정 요일' 템플릿 단건 조회 (오늘 요일 템플릿 꺼내올 때 사용)
+    Optional<WeeklyTimeDistribution> findByChildIdAndDayOfWeek(Long childId, DayOfWeek dayOfWeek);
+
+    // 특정 자녀의 '일주일치 전체' 템플릿 조회 (자녀가 주간 계획표 화면을 열었을 때 사용)
+    List<WeeklyTimeDistribution> findAllByChildId(Long childId);
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
@@ -125,4 +125,43 @@ public class ScheduleService {
         WeeklyRoutine routine = routineRepository.findById(routineId).orElseThrow();
         routineRepository.delete(routine);
     }
+    /**
+     하루 마무리 시 실제 사용 시간을 기록하고 남은 시간을 보상 풀로 환불하기
+     * @param actualUsedMinutes 자녀가 오늘 실제로 스마트폰을 사용한 시간 (분 단위)
+     */
+    @Transactional
+    public DailyTimeAllocation settleDailyTime(Long childId, LocalDate targetDate, int actualUsedMinutes) {
+
+        // 1. 오늘의 스케줄 배정 데이터 가져오기
+        DailyTimeAllocation allocation = dailyRepository.findByChildIdAndTargetDate(childId, targetDate)
+                .orElseThrow(() -> new IllegalArgumentException("오늘 생성된 시간표 데이터가 없습니다."));
+
+        // 오늘 자녀에게 주어졌던 총 가용 시간 계산 (기본시간 + 연장된시간)
+        int totalAllocatedTime = allocation.getTotalAvailableTime();
+
+        // 가드 로직: 혹시 실제 사용 시간이 준 시간보다 많으면 연산 오류이므로 방어
+        if (actualUsedMinutes > totalAllocatedTime) {
+            throw new IllegalArgumentException("실제 사용 시간이 할당된 총 시간을 초과할 수 없습니다.");
+        }
+
+        // 남은 시간 계산하기 (할당량 - 실제 사용량)
+        int unusedMinutes = totalAllocatedTime - actualUsedMinutes;
+
+        // 남은 시간이 존재한다면 부모 정책(TimePolicy) 데이터에 환불 절차 진행
+        if (unusedMinutes > 0) {
+            String yearMonth = targetDate.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+            TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책을 찾을 수 없습니다."));
+
+            // TimePolicy의 보상 풀에 남은 시간만큼 플러스(+) 처리
+            policy.refundUnusedTime(unusedMinutes);
+        }
+
+        // 오늘자 할당 기록의 baseMinutes와 extendedMinutes를 정산된 결과에 맞게 재조정
+        // 가장 깔끔한 방법은 오늘 가용시간 자체를 자녀가 실제 사용한 시간으로 락(Lock)을 걸어두는 것
+        // 다음 스케줄 조회 시 정산된 결과가 보이도록 엔티티 값을 세팅
+        allocation.updateToSettledTime(actualUsedMinutes);
+
+        return allocation;
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
@@ -1,0 +1,128 @@
+package me.sogom.bridge.domain.schedule.service;
+
+import lombok.RequiredArgsConstructor;
+import me.sogom.bridge.domain.member.entity.Children;
+import me.sogom.bridge.domain.member.repository.ChildrenRepository;
+import me.sogom.bridge.domain.policy.entity.TimePolicy;
+import me.sogom.bridge.domain.policy.repository.TimePolicyRepository;
+import me.sogom.bridge.domain.schedule.dto.RoutineRequest;
+import me.sogom.bridge.domain.schedule.dto.WeeklyTemplateRequest;
+import me.sogom.bridge.domain.schedule.entity.DailyTimeAllocation;
+import me.sogom.bridge.domain.schedule.entity.WeeklyRoutine;
+import me.sogom.bridge.domain.schedule.entity.WeeklyTimeDistribution;
+import me.sogom.bridge.domain.schedule.repository.DailyTimeAllocationRepository;
+import me.sogom.bridge.domain.schedule.repository.WeeklyRoutineRepository;
+import me.sogom.bridge.domain.schedule.repository.WeeklyTimeDistributionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleService {
+
+    private final WeeklyTimeDistributionRepository weeklyRepository;
+    private final DailyTimeAllocationRepository dailyRepository;
+    private final ChildrenRepository childrenRepository;
+    private final TimePolicyRepository timePolicyRepository;
+    private final WeeklyRoutineRepository routineRepository;
+
+    //오늘의 실제 제한 시간 조회 (없으면 요일 템플릿에서 동적 복사)
+    @Transactional
+    public DailyTimeAllocation getOrCreateDailyAllocation(Long childId, LocalDate targetDate) {
+        // 오늘 날짜의 데이터가 이미 있는지 DB에서 확인
+        return dailyRepository.findByChildIdAndTargetDate(childId, targetDate)
+                .orElseGet(() -> {
+                    // 없다면 오늘이 무슨 요일인지 확인
+                    DayOfWeek dayOfWeek = targetDate.getDayOfWeek();
+
+                    // 해당 요일의 '기본 템플릿(Weekly)'을 가져오기
+                    WeeklyTimeDistribution template = weeklyRepository.findByChildIdAndDayOfWeek(childId, dayOfWeek)
+                            .orElseThrow(() -> new IllegalArgumentException("해당 요일의 기본 시간표 설정이 없습니다."));
+
+                    // 자녀 엔티티 조회
+                    Children child = childrenRepository.findById(childId).orElseThrow();
+
+                    // 템플릿의 시간을 복사해서 '오늘(Daily)' 데이터를 새로 저장
+                    DailyTimeAllocation newAllocation = DailyTimeAllocation.builder()
+                            .child(child)
+                            .targetDate(targetDate)
+                            .baseMinutes(template.getBaseMinutes())
+                            .extendedMinutes(0) // 처음 생성될 때는 연장 시간이 0분
+                            .build();
+
+                    return dailyRepository.save(newAllocation);
+                });
+    }
+
+    //자녀가 여분(보상) 시간을 사용해 오늘 시간을 연장할 때
+    @Transactional
+    public DailyTimeAllocation extendDailyTime(Long childId, LocalDate targetDate, int extraMinutes) {
+
+        //날짜 변환 ("yyyy-MM" 형태)
+        String yearMonth = targetDate.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+
+        //DB에서 이번 달 부모 정책 정보 가져오기
+        TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
+                .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책이 설정되지 않았습니다."));
+
+        //엔티티의 차감 로직 호출 (알아서 기본시간->보상시간 순으로 깎고, 부족하면 에러를 던짐)
+        policy.deductAvailableTime(extraMinutes);
+
+        //오늘의 스케줄 데이터를 가져오기
+        DailyTimeAllocation allocation = getOrCreateDailyAllocation(childId, targetDate);
+
+        //오늘 스케줄에 시간을 연장하기
+        allocation.addExtraTime(extraMinutes);
+
+        return allocation;
+    }
+    //자녀가 최초/매주 요일별 기본 가용 시간(템플릿) 설정 및 수정
+    @Transactional
+    public void updateWeeklyTemplate(Long childId, WeeklyTemplateRequest request) {
+        WeeklyTimeDistribution weeklyDist = weeklyRepository.findByChildIdAndDayOfWeek(childId, request.getDayOfWeek())
+                .orElseGet(() -> {
+                    Children child = childrenRepository.findById(childId).orElseThrow();
+                    return WeeklyTimeDistribution.builder()
+                            .child(child)
+                            .dayOfWeek(request.getDayOfWeek())
+                            .build();
+                });
+
+        weeklyDist.updateBaseMinutes(request.getBaseMinutes());
+        weeklyRepository.save(weeklyDist);
+    }
+
+    //\학원/고정 일정(Routine) 등록
+    @Transactional
+    public void createRoutine(Long childId, RoutineRequest request) {
+        Children child = childrenRepository.findById(childId).orElseThrow();
+
+        WeeklyRoutine routine = WeeklyRoutine.builder()
+                .child(child)
+                .dayOfWeek(request.getDayOfWeek())
+                .startTime(request.getStartTime())
+                .endTime(request.getEndTime())
+                .title(request.getTitle())
+                .build();
+
+        routineRepository.save(routine);
+    }
+
+    //자녀의 주간 고정 일정 전체 조회 (시간표 조각들 목록)
+    @Transactional(readOnly = true)
+    public List<WeeklyRoutine> getWeeklyRoutines(Long childId) {
+        return routineRepository.findAllByChild_Id(childId);
+    }
+
+    //고정 일정 삭제
+    @Transactional
+    public void deleteRoutine(Long routineId) {
+        WeeklyRoutine routine = routineRepository.findById(routineId).orElseThrow();
+        routineRepository.delete(routine);
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
@@ -82,16 +82,36 @@ public class ScheduleService {
         return allocation;
     }
     //자녀가 최초/매주 요일별 기본 가용 시간(템플릿) 설정 및 수정
+    //요일별 기본 템플릿 설정 초과 등록 버그 수정
     @Transactional
     public void updateWeeklyTemplate(Long childId, WeeklyTemplateRequest request) {
+        String yearMonth = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
+        TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
+                .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책이 설정되지 않았습니다."));
+
+        //현재 DB에 저장되어 있는 이 자녀의 월~일 전체 기본 틀 시간의 합을 구함
+        List<WeeklyTimeDistribution> allTemplates = weeklyRepository.findAllByChildId(childId);
+
+        int currentWeeklySum = allTemplates.stream()
+                // 지금 수정하려는 요일의 기존 시간은 제외하고 나머지 요일들만 합산
+                .filter(t -> !t.getDayOfWeek().equals(request.getDayOfWeek()))
+                .mapToInt(WeeklyTimeDistribution::getBaseMinutes)
+                .sum();
+
+        //여기에 새로 등록/수정하려는 요일의 시간을 더해봄
+        int expectedWeeklySum = currentWeeklySum + request.getBaseMinutes();
+
+        // 일주일 기본 틀의 합이 부모 저금통의 한도를 초과하면 즉시 차단!
+        if (expectedWeeklySum > policy.getBaseTime()) {
+            throw new IllegalArgumentException("주간 시간표의 총합(" + expectedWeeklySum + "분)이 부모님이 설정한 이번 달 총 가용 시간(" + policy.getBaseTime() + "분)을 초과할 수 없습니다!");
+        }
+
+        // 안전함이 검증되었을 때만 DB에 반영
         WeeklyTimeDistribution weeklyDist = weeklyRepository.findByChildIdAndDayOfWeek(childId, request.getDayOfWeek())
-                .orElseGet(() -> {
-                    Children child = childrenRepository.findById(childId).orElseThrow();
-                    return WeeklyTimeDistribution.builder()
-                            .child(child)
-                            .dayOfWeek(request.getDayOfWeek())
-                            .build();
-                });
+                .orElseGet(() -> WeeklyTimeDistribution.builder()
+                        .child(policy.getChild())
+                        .dayOfWeek(request.getDayOfWeek())
+                        .build());
 
         weeklyDist.updateBaseMinutes(request.getBaseMinutes());
         weeklyRepository.save(weeklyDist);

--- a/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
@@ -44,6 +44,17 @@ public class ScheduleService {
                     WeeklyTimeDistribution template = weeklyRepository.findByChildIdAndDayOfWeek(childId, dayOfWeek)
                             .orElseThrow(() -> new IllegalArgumentException("해당 요일의 기본 시간표 설정이 없습니다."));
 
+                    // 이번 달 부모 정책 가져오기
+                    String yearMonth = targetDate.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+                    TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
+                            .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책이 설정되지 않았습니다."));
+
+                    // 템플릿에 설정된 설정 시간만큼 기본 시간에서 선차감 진행
+                    policy.deductAvailableTime(template.getBaseMinutes());
+
+                    // 변경된 상태를 DB에 확실하게 즉시 업데이트(UPDATE)
+                    timePolicyRepository.save(policy);
+
                     // 자녀 엔티티 조회
                     Children child = childrenRepository.findById(childId).orElseThrow();
 


### PR DESCRIPTION
## 주요 진행사항
1. 보안 및 인증 구조 반영
- [x] 기존 URL 경로 변수(childId) 방식에서 SecurityContext의 AuthMember 인증 객체를 사용하는 방식으로 변경하여 비정상적 데이터 접근 차단

2. 주간 시간표 템플릿 설정 및 초과 등록 제한
- [x] 요일별 기본 가용 시간을 설정하는 API 구현 (PUT /api/v1/schedules/templates)

- [x] 등록 시점에 일주일 계획 총합 시간이 부모 정책의 baseTime 한도를 초과할 경우 예외를 발생시켜 차단하는 검증 가드 로직 추가

3. 일일 시간 제한량 조회 및 선차감 자동화
- [x] 일일 시간표 최초 조회 시 요일 템플릿 정보를 기반으로 당일 데이터를 동적 복사 및 생성하는 로직 구현 (GET /api/v1/schedules/daily)

- [x] 당일 데이터 최초 동적 생성 시 부모 정책의 baseTime에서 해당 분량만큼 즉시 차감하는 선차감 트랜잭션 연동 및 명시적 영속화 반영

4. 시간 연장 기능 구현
- [x] 자녀의 추가 시간 연장 요청에 따라 당일 가용 시간을 증가시키는 API 구현 (POST /api/v1/schedules/extend)

- [x] 연장 분량만큼 부모 정책 잔액(baseTime 선차감 후 부족분은 accumulatedRewardTime 차감)에서 추가로 차감 처리 연동 및 영속화 반영

5. 하루 마감 정산 및 미사용 분량 복구
- [x] 당일 실제 사용 시간을 기록하여 정산 마감하는 API 구현 (POST /api/v1/schedules/settle)

- [x] 당일 전체 할당 시간 중 사용하지 않고 남은 잔여 분량을 계산하여 부모 정책의 baseTime 저금통으로 전액 반환 및 복구 처리

6. 고정 일정(Routine) 관리 CRUD 구현 및 DTO 도입
- [x] 요일별 학원 일정의 등록, 조회, 삭제 API 구현 (/api/v1/schedules/routines)

- [x] 전체 조회 API 실행 시 엔티티 직접 반환으로 인해 발생하던 순환 참조 및 무한 로딩 이슈를 해결하기 위해 가상 필드를 제한한 RoutineResponse DTO 클래스 도입 및 리스트 전환 처리 반영

## 테스트 진행

- [x] 주간 템플릿 설정 및 등록 시점 총량 한도 검증

- [x] 정상 범위 내 요일별 시간 등록 완료 확인

- [x] 부모 정책 총량 초과 설정 시 예외 반환 및 등록 차단 확인

- [x] 일일 시간표 조회 및 기본 가용량 선차감 검증

- [x] 최초 조회 시 당일 시간표 데이터 동적 생성 및 영속화 확인

- [x] 생성 즉시 부모 정책 잔액에서 기본 가용 분량 차감 완료 확인

- [x] 시간 연장 처리 및 추가 차감 검증

- [x] 추가 시간 연장 요청 시 일일 제한 시간 증가 반영 확인

- [x] 부모 정책 잔액에서 연장 분량만큼 추가로 차감 처리 연동 확인

- [x] 하루 마감 정산 및 잔여 분량 복구 검증

- [x] 실제 사용 시간에 따른 당일 시간표 정산 고정 확인

- [x] 미사용 잔여 시간을 부모 정책 기본 가용 잔액으로 전액 반환 및 정합성 확인

- [x] 고정 일정 CRUD 및 DTO 매핑 검증

- [x] 학원 고정 일정의 등록, 조회, 삭제 작동 확인

- [x] 엔티티 직접 반환으로 인해 발생하던 객체 관계 연쇄 로딩 및 순환 참조 문제를 DTO 그릇 구조 전환을 통해 원천 해결하여 정제된 응답 데이터 포맷 확인

## 관련 이슈사항
- Closes https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/28
- Relates to https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/28