### PR TITLE
Feat: 주간 및 일일 시간표(Schedule) 관리 기능 구현 수정본

### DIFF
--- a/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
@@ -46,4 +46,26 @@ public class TimePolicy extends BaseEntity {
     }
 
     public void updateBaseTime(int baseTime) { this.baseTime = baseTime; }
+
+    //기본 제공 시간과 보상 시간을 합쳐서 연장할 시간을 차감 (기본 시간에서 먼저 차감하고, 부족하면 보상 시간에서 차감)
+
+    public void deductAvailableTime(int minutes) {
+        int totalAvailable = this.baseTime + this.accumulatedRewardTime;
+
+        // 전체 가용 시간(기본+보상)이 연장하려는 시간보다 적은지 검문
+        if (totalAvailable < minutes) {
+            throw new IllegalArgumentException("사용 가능한 총 시간(기본+보상)이 부족하여 연장할 수 없습니다.");
+        }
+
+        // 기본 시간이 충분히 남아있다면 기본 시간에서만 차감
+        if (this.baseTime >= minutes) {
+            this.baseTime -= minutes;
+        }
+        // 기본 시간이 모자라다면, 기본 시간을 0으로 만들고 남은 만큼을 보상 시간에서 차감
+        else {
+            int remainder = minutes - this.baseTime;
+            this.baseTime = 0;
+            this.accumulatedRewardTime -= remainder;
+        }
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
@@ -68,4 +68,11 @@ public class TimePolicy extends BaseEntity {
             this.accumulatedRewardTime -= remainder;
         }
     }
+    //자녀가 당일에 쓰지 않고 남긴 시간을 보상 시간 풀로 다시 환불(적립)해주는 메서드
+    public void refundUnusedTime(int unusedMinutes) {
+        if (unusedMinutes < 0) {
+            throw new IllegalArgumentException("적립할 시간은 음수일 수 없습니다.");
+        }
+        this.accumulatedRewardTime += unusedMinutes;
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
@@ -86,4 +86,16 @@ public class ScheduleController {
         scheduleService.deleteRoutine(routineId);
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, "일정이 삭제되었습니다.");
     }
+    //[POST] 자녀의 당일 가용 시간 최종 정산 및 잔여 시간 보상 풀 환불
+    // URL 예시: POST /api/v1/children/1/schedules/settle?actualUsed=100
+    @PostMapping("/settle")
+    public ApiResponse<DailyScheduleResponse> settleDailyTime(
+            @PathVariable Long childId,
+            @RequestParam int actualUsed,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+
+        DailyTimeAllocation settledAllocation = scheduleService.settleDailyTime(childId, date, actualUsed);
+
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, DailyScheduleResponse.from(settledAllocation));
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
@@ -109,4 +109,14 @@ public class ScheduleController {
         scheduleService.deleteRoutine(routineId);
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, "일정이 정상적으로 삭제되었습니다.");
     }
+
+    @PostMapping("/weekly-budgets")
+    public ApiResponse<Void> createWeeklyBudgets(
+            @AuthenticationPrincipal AuthMember user,
+            @RequestParam String yearMonth,
+            @RequestBody List<WeeklyBudgetRequest> requests) { //리스트 내부 객체 타입 명시
+
+        scheduleService.createWeeklyBudgets(user.asChildren().getId(), yearMonth, requests);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, null);
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
@@ -2,21 +2,15 @@ package me.sogom.bridge.domain.schedule.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import me.sogom.bridge.domain.schedule.dto.DailyScheduleResponse;
-import me.sogom.bridge.domain.schedule.dto.RoutineRequest;
-import me.sogom.bridge.domain.schedule.dto.TimeExtensionRequest;
-import me.sogom.bridge.domain.schedule.dto.WeeklyTemplateRequest;
+import me.sogom.bridge.domain.schedule.dto.*;
 import me.sogom.bridge.domain.schedule.entity.DailyTimeAllocation;
 import me.sogom.bridge.domain.schedule.entity.WeeklyRoutine;
 import me.sogom.bridge.domain.schedule.service.ScheduleService;
 import me.sogom.bridge.global.apiPayload.ApiResponse;
 import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
-
-// 시큐리티 및 인증 객체 임포트
 import me.sogom.bridge.global.security.entity.AuthMember;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -91,14 +85,20 @@ public class ScheduleController {
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, "고정 일정이 성공적으로 등록되었습니다.");
     }
 
-    //[GET] 자녀의 주간 학원/고정 일정 전체 조회
+    //[GET] 자녀의 주간 학원/고정 일정 전체 조회 (DTO 필터 적용 버전!)
     @GetMapping("/routines")
-    public ApiResponse<List<WeeklyRoutine>> getWeeklyRoutines(
+    public ApiResponse<List<RoutineResponse>> getWeeklyRoutines(
             @AuthenticationPrincipal AuthMember user) {
 
         Long childId = user.asChildren().getId();
         List<WeeklyRoutine> routines = scheduleService.getWeeklyRoutines(childId);
-        return ApiResponse.onSuccess(GeneralSuccessCode.OK, routines);
+
+        // 🌟 거대했던 엔티티 뭉치들을 깔끔한 RoutineResponse DTO 리스트로 변환합니다.
+        List<RoutineResponse> response = routines.stream()
+                .map(RoutineResponse::from)
+                .toList();
+
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, response);
     }
 
     //[DELETE] 학원 고정 일정 삭제

--- a/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
@@ -11,6 +11,11 @@ import me.sogom.bridge.domain.schedule.entity.WeeklyRoutine;
 import me.sogom.bridge.domain.schedule.service.ScheduleService;
 import me.sogom.bridge.global.apiPayload.ApiResponse;
 import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
+
+// 시큐리티 및 인증 객체 임포트
+import me.sogom.bridge.global.security.entity.AuthMember;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,83 +24,89 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/children/{childId}/schedules")
+@RequestMapping("/api/v1/schedules")
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
 
-    //URL 예시: GET /api/v1/children/1/schedules/daily?date=2026-05-16
+    //[GET] 자녀의 특정 날짜 시간표 조회
     @GetMapping("/daily")
     public ApiResponse<DailyScheduleResponse> getDailySchedule(
-            @PathVariable Long childId,
+            @AuthenticationPrincipal AuthMember user,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
 
-        //서비스 비즈니스 로직 호출 (조회 혹은 자동 동적 생성)
+        //자녀 엔티티를 꺼낸 후 ID를 추출
+        Long childId = user.asChildren().getId();
         DailyTimeAllocation allocation = scheduleService.getOrCreateDailyAllocation(childId, date);
 
         //GeneralSuccessCode.OK에 응답 데이터를 저장 후 return
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, DailyScheduleResponse.from(allocation));
     }
 
-    //URL 예시: POST /api/v1/children/1/schedules/extend
+    //[POST] 자녀의 특정 날짜 시간 연장
     @PostMapping("/extend")
     public ApiResponse<DailyScheduleResponse> extendDailyTime(
-            @PathVariable Long childId,
+            @AuthenticationPrincipal AuthMember user,
             @Valid @RequestBody TimeExtensionRequest request) {
 
         //부모 보상 시간 차감 및 오늘 제한 시간 증가
+        Long childId = user.asChildren().getId();
         DailyTimeAllocation updatedAllocation = scheduleService.extendDailyTime(
-                childId,
-                request.getTargetDate(),
-                request.getExtraMinutes()
+                childId, request.getTargetDate(), request.getExtraMinutes()
         );
 
         //업데이트 완료된 데이터를 공통 규격에 맞춰 return
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, DailyScheduleResponse.from(updatedAllocation));
     }
-    //[PUT] 주간 요일별 가용시간 기본 틀(템플릿) 설정/수정
-    @PutMapping("/templates")
-    public ApiResponse<String> updateWeeklyTemplate(
-            @PathVariable Long childId,
-            @RequestBody WeeklyTemplateRequest request) {
-        scheduleService.updateWeeklyTemplate(childId, request);
-        return ApiResponse.onSuccess(GeneralSuccessCode.OK, "요일별 기본 가용 시간이 설정되었습니다.");
+
+    //[POST] 당일 사용 시간 최종 정산 및 잔여 시간 보상 풀 환불 마감
+    @PostMapping("/settle")
+    public ApiResponse<DailyScheduleResponse> settleDailyTime(
+            @AuthenticationPrincipal AuthMember user,
+            @RequestParam int actualUsed,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+
+        Long childId = user.asChildren().getId();
+        DailyTimeAllocation settledAllocation = scheduleService.settleDailyTime(childId, date, actualUsed);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, DailyScheduleResponse.from(settledAllocation));
     }
 
-    //[POST] 학원 고정 일정 등록
+    //[PUT] 주간 요일별 가용시간 기본 틀(템플릿) 설정 및 수정
+    @PutMapping("/templates")
+    public ApiResponse<String> updateWeeklyTemplate(
+            @AuthenticationPrincipal AuthMember user,
+            @RequestBody WeeklyTemplateRequest request) {
+        Long childId = user.asChildren().getId();
+        scheduleService.updateWeeklyTemplate(childId, request);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, "요일별 기본 가용 시간이 성공적으로 설정되었습니다.");
+    }
+
+    //[POST] 학원 고정 일정(Routine) 등록
     @PostMapping("/routines")
     public ApiResponse<String> createRoutine(
-            @PathVariable Long childId,
+            @AuthenticationPrincipal AuthMember user,
             @RequestBody RoutineRequest request) {
+        Long childId = user.asChildren().getId();
         scheduleService.createRoutine(childId, request);
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, "고정 일정이 성공적으로 등록되었습니다.");
     }
 
-    //[GET] 자녀의 주간 학원/고정 일정 전체 조회 (참고용 시간표 뷰에 그려짐)
+    //[GET] 자녀의 주간 학원/고정 일정 전체 조회
     @GetMapping("/routines")
-    public ApiResponse<List<WeeklyRoutine>> getWeeklyRoutines(@PathVariable Long childId) {
+    public ApiResponse<List<WeeklyRoutine>> getWeeklyRoutines(
+            @AuthenticationPrincipal AuthMember user) {
+
+        Long childId = user.asChildren().getId();
         List<WeeklyRoutine> routines = scheduleService.getWeeklyRoutines(childId);
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, routines);
     }
 
-    //[DELETE] 고정 일정 삭제
+    //[DELETE] 학원 고정 일정 삭제
     @DeleteMapping("/routines/{routineId}")
     public ApiResponse<String> deleteRoutine(
-            @PathVariable Long childId,
+            @AuthenticationPrincipal AuthMember user,
             @PathVariable Long routineId) {
         scheduleService.deleteRoutine(routineId);
-        return ApiResponse.onSuccess(GeneralSuccessCode.OK, "일정이 삭제되었습니다.");
-    }
-    //[POST] 자녀의 당일 가용 시간 최종 정산 및 잔여 시간 보상 풀 환불
-    // URL 예시: POST /api/v1/children/1/schedules/settle?actualUsed=100
-    @PostMapping("/settle")
-    public ApiResponse<DailyScheduleResponse> settleDailyTime(
-            @PathVariable Long childId,
-            @RequestParam int actualUsed,
-            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
-
-        DailyTimeAllocation settledAllocation = scheduleService.settleDailyTime(childId, date, actualUsed);
-
-        return ApiResponse.onSuccess(GeneralSuccessCode.OK, DailyScheduleResponse.from(settledAllocation));
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, "일정이 정상적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
@@ -1,0 +1,89 @@
+package me.sogom.bridge.domain.schedule.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import me.sogom.bridge.domain.schedule.dto.DailyScheduleResponse;
+import me.sogom.bridge.domain.schedule.dto.RoutineRequest;
+import me.sogom.bridge.domain.schedule.dto.TimeExtensionRequest;
+import me.sogom.bridge.domain.schedule.dto.WeeklyTemplateRequest;
+import me.sogom.bridge.domain.schedule.entity.DailyTimeAllocation;
+import me.sogom.bridge.domain.schedule.entity.WeeklyRoutine;
+import me.sogom.bridge.domain.schedule.service.ScheduleService;
+import me.sogom.bridge.global.apiPayload.ApiResponse;
+import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/children/{childId}/schedules")
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    //URL 예시: GET /api/v1/children/1/schedules/daily?date=2026-05-16
+    @GetMapping("/daily")
+    public ApiResponse<DailyScheduleResponse> getDailySchedule(
+            @PathVariable Long childId,
+            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+
+        //서비스 비즈니스 로직 호출 (조회 혹은 자동 동적 생성)
+        DailyTimeAllocation allocation = scheduleService.getOrCreateDailyAllocation(childId, date);
+
+        //GeneralSuccessCode.OK에 응답 데이터를 저장 후 return
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, DailyScheduleResponse.from(allocation));
+    }
+
+    //URL 예시: POST /api/v1/children/1/schedules/extend
+    @PostMapping("/extend")
+    public ApiResponse<DailyScheduleResponse> extendDailyTime(
+            @PathVariable Long childId,
+            @Valid @RequestBody TimeExtensionRequest request) {
+
+        //부모 보상 시간 차감 및 오늘 제한 시간 증가
+        DailyTimeAllocation updatedAllocation = scheduleService.extendDailyTime(
+                childId,
+                request.getTargetDate(),
+                request.getExtraMinutes()
+        );
+
+        //업데이트 완료된 데이터를 공통 규격에 맞춰 return
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, DailyScheduleResponse.from(updatedAllocation));
+    }
+    //[PUT] 주간 요일별 가용시간 기본 틀(템플릿) 설정/수정
+    @PutMapping("/templates")
+    public ApiResponse<String> updateWeeklyTemplate(
+            @PathVariable Long childId,
+            @RequestBody WeeklyTemplateRequest request) {
+        scheduleService.updateWeeklyTemplate(childId, request);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, "요일별 기본 가용 시간이 설정되었습니다.");
+    }
+
+    //[POST] 학원 고정 일정 등록
+    @PostMapping("/routines")
+    public ApiResponse<String> createRoutine(
+            @PathVariable Long childId,
+            @RequestBody RoutineRequest request) {
+        scheduleService.createRoutine(childId, request);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, "고정 일정이 성공적으로 등록되었습니다.");
+    }
+
+    //[GET] 자녀의 주간 학원/고정 일정 전체 조회 (참고용 시간표 뷰에 그려짐)
+    @GetMapping("/routines")
+    public ApiResponse<List<WeeklyRoutine>> getWeeklyRoutines(@PathVariable Long childId) {
+        List<WeeklyRoutine> routines = scheduleService.getWeeklyRoutines(childId);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, routines);
+    }
+
+    //[DELETE] 고정 일정 삭제
+    @DeleteMapping("/routines/{routineId}")
+    public ApiResponse<String> deleteRoutine(
+            @PathVariable Long childId,
+            @PathVariable Long routineId) {
+        scheduleService.deleteRoutine(routineId);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, "일정이 삭제되었습니다.");
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/DailyScheduleResponse.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/DailyScheduleResponse.java
@@ -1,0 +1,28 @@
+package me.sogom.bridge.domain.schedule.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import me.sogom.bridge.domain.schedule.entity.DailyTimeAllocation;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class DailyScheduleResponse {
+    private Long id;
+    private LocalDate targetDate;
+    private int baseMinutes;
+    private int extendedMinutes;
+    private int totalAvailableMinutes;
+
+    // 엔티티를 DTO로 변환
+    public static DailyScheduleResponse from(DailyTimeAllocation allocation) {
+        return DailyScheduleResponse.builder()
+                .id(allocation.getId())
+                .targetDate(allocation.getTargetDate())
+                .baseMinutes(allocation.getBaseMinutes())
+                .extendedMinutes(allocation.getExtendedMinutes())
+                .totalAvailableMinutes(allocation.getTotalAvailableTime())
+                .build();
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/RoutineRequest.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/RoutineRequest.java
@@ -1,0 +1,13 @@
+//학원 일정 등록 요청 DTO
+package me.sogom.bridge.domain.schedule.dto;
+import lombok.Getter;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+@Getter
+public class RoutineRequest {
+    private DayOfWeek dayOfWeek;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private String title;
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/RoutineRequest.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/RoutineRequest.java
@@ -9,5 +9,4 @@ public class RoutineRequest {
     private DayOfWeek dayOfWeek;
     private LocalTime startTime;
     private LocalTime endTime;
-    private String title;
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/RoutineResponse.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/RoutineResponse.java
@@ -15,7 +15,6 @@ public class RoutineResponse {
     private DayOfWeek dayOfWeek;
     private LocalTime startTime;
     private LocalTime endTime;
-    private String title;
 
     // 엔티티를 안전하고 깔끔한 DTO로 변환해주는 메서드
     public static RoutineResponse from(WeeklyRoutine routine) {
@@ -24,7 +23,6 @@ public class RoutineResponse {
                 .dayOfWeek(routine.getDayOfWeek())
                 .startTime(routine.getStartTime())
                 .endTime(routine.getEndTime())
-                .title(routine.getTitle())
                 .build();
     }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/RoutineResponse.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/RoutineResponse.java
@@ -1,0 +1,30 @@
+package me.sogom.bridge.domain.schedule.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import me.sogom.bridge.domain.schedule.entity.WeeklyRoutine;
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class RoutineResponse {
+    private Long id;
+    private DayOfWeek dayOfWeek;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private String title;
+
+    // 엔티티를 안전하고 깔끔한 DTO로 변환해주는 메서드
+    public static RoutineResponse from(WeeklyRoutine routine) {
+        return RoutineResponse.builder()
+                .id(routine.getId())
+                .dayOfWeek(routine.getDayOfWeek())
+                .startTime(routine.getStartTime())
+                .endTime(routine.getEndTime())
+                .title(routine.getTitle())
+                .build();
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/TimeExtensionRequest.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/TimeExtensionRequest.java
@@ -1,0 +1,16 @@
+package me.sogom.bridge.domain.schedule.dto;
+
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class TimeExtensionRequest {
+    private LocalDate targetDate;
+
+    @Min(value = 1, message = "연장할 시간은 1분 이상이어야 합니다.")
+    private int extraMinutes;
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/WeeklyBudgetRequest.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/WeeklyBudgetRequest.java
@@ -1,0 +1,9 @@
+package me.sogom.bridge.domain.schedule.dto;
+
+import lombok.Getter;
+
+@Getter
+public class WeeklyBudgetRequest {
+    private int weekNumber;
+    private int allocatedMinutes;
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/WeeklyTemplateRequest.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/WeeklyTemplateRequest.java
@@ -1,10 +1,15 @@
 //요일별 기본 분배 시간 설정 요청 DTO
 package me.sogom.bridge.domain.schedule.dto;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import java.time.DayOfWeek;
 
 @Getter
+@NoArgsConstructor // 역직렬화를 위한 기본 생성자
 public class WeeklyTemplateRequest {
+    private String yearMonth;   // 예: "2026-05"
+    private int weekNumber;     // 예: 1 (1주차)
+
     private DayOfWeek dayOfWeek;
     private int baseMinutes;
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/WeeklyTemplateRequest.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/WeeklyTemplateRequest.java
@@ -1,0 +1,10 @@
+//요일별 기본 분배 시간 설정 요청 DTO
+package me.sogom.bridge.domain.schedule.dto;
+import lombok.Getter;
+import java.time.DayOfWeek;
+
+@Getter
+public class WeeklyTemplateRequest {
+    private DayOfWeek dayOfWeek;
+    private int baseMinutes;
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/entity/DailyTimeAllocation.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/entity/DailyTimeAllocation.java
@@ -1,0 +1,55 @@
+package me.sogom.bridge.domain.schedule.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.sogom.bridge.domain.common.BaseEntity;
+import me.sogom.bridge.domain.member.entity.Children;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@EnableJpaAuditing
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "daily_time_allocations")
+public class DailyTimeAllocation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "child_id", nullable = false)
+    private Children child;
+
+    @Column(name = "target_date", nullable = false)
+    private LocalDate targetDate; // 연장이 일어나는 구체적인 날짜 (예: 2026-05-16)
+
+    @Column(name = "base_minutes", nullable = false)
+    private int baseMinutes; // 그날 요일의 템플릿에서 복사해온 기본 시간
+
+    @Column(name = "extended_minutes", nullable = false)
+    private int extendedMinutes; // 자녀가 보상이나 여분으로 추가 연장한 시간
+
+    @Builder
+    public DailyTimeAllocation(Children child, LocalDate targetDate, int baseMinutes, int extendedMinutes) {
+        this.child = child;
+        this.targetDate = targetDate;
+        this.baseMinutes = baseMinutes;
+        this.extendedMinutes = extendedMinutes;
+    }
+
+    // 객체지향 비즈니스 메서드: 오늘의 시간 추가 연장
+    public void addExtraTime(int minutes) {
+        this.extendedMinutes += minutes;
+    }
+
+    // 최종 자녀 폰에 적용될 제한 시간 계산용 메서드
+    public int getTotalAvailableTime() {
+        return this.baseMinutes + this.extendedMinutes;
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/entity/DailyTimeAllocation.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/entity/DailyTimeAllocation.java
@@ -52,4 +52,10 @@ public class DailyTimeAllocation extends BaseEntity {
     public int getTotalAvailableTime() {
         return this.baseMinutes + this.extendedMinutes;
     }
+
+    //당일 사용 시간을 실제로 자녀가 사용한 시간으로 최종 정산
+    public void updateToSettledTime(int actualUsedMinutes) {
+        this.baseMinutes = actualUsedMinutes;
+        this.extendedMinutes = 0; // 정산이 끝났으므로 연장 시간 변수는 0으로 리셋
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/entity/WeeklyBudget.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/entity/WeeklyBudget.java
@@ -1,0 +1,34 @@
+package me.sogom.bridge.domain.schedule.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.sogom.bridge.domain.member.entity.Children;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "weekly_budgets")
+public class WeeklyBudget {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "child_id")
+    private Children child;
+
+    private String yearMonth; // 예: "2026-05"
+    private int weekNumber;   // 1, 2, 3, 4 주차
+    private int allocatedMinutes; // 할당된 시간
+
+    @Builder
+    public WeeklyBudget(Children child, String yearMonth, int weekNumber, int allocatedMinutes) {
+        this.child = child;
+        this.yearMonth = yearMonth;
+        this.weekNumber = weekNumber;
+        this.allocatedMinutes = allocatedMinutes;
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/entity/WeeklyRoutine.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/entity/WeeklyRoutine.java
@@ -1,0 +1,57 @@
+package me.sogom.bridge.domain.schedule.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.sogom.bridge.domain.common.BaseEntity;
+import me.sogom.bridge.domain.member.entity.Children;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "weekly_routines")
+public class WeeklyRoutine extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "weekly_routine_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "children_id", nullable = false)
+    private Children child;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DayOfWeek dayOfWeek; // MONDAY, TUESDAY ...
+
+    @Column(nullable = false)
+    private LocalTime startTime; // 예: 16:00
+
+    @Column(nullable = false)
+    private LocalTime endTime; // 예: 18:00
+
+    @Column(nullable = false)
+    private String title; // 예: "영어학원"
+
+    @Builder
+    public WeeklyRoutine(Children child, DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime, String title) {
+        this.child = child;
+        this.dayOfWeek = dayOfWeek;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.title = title;
+    }
+
+    public void updateRoutine(DayOfWeek dayOfWeek, LocalTime startTime, LocalTime endTime, String title) {
+        this.dayOfWeek = dayOfWeek;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.title = title;
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/entity/WeeklyTimeDistribution.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/entity/WeeklyTimeDistribution.java
@@ -34,10 +34,15 @@ public class WeeklyTimeDistribution extends BaseEntity {
     @Column(name = "base_minutes", nullable = false)
     private int baseMinutes; // 요일별 기본 세팅 시간 (분 단위)
 
+    private String yearMonth; // 예: "2026-05"
+    private int weekNumber;   // 1~5 주차
+
     @Builder
-    public WeeklyTimeDistribution(Children child, DayOfWeek dayOfWeek, int baseMinutes) {
+    public WeeklyTimeDistribution(Children child, DayOfWeek dayOfWeek, String yearMonth, int weekNumber, int baseMinutes) {
         this.child = child;
         this.dayOfWeek = dayOfWeek;
+        this.yearMonth = yearMonth;
+        this.weekNumber = weekNumber;
         this.baseMinutes = baseMinutes;
     }
 

--- a/src/main/java/me/sogom/bridge/domain/schedule/entity/WeeklyTimeDistribution.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/entity/WeeklyTimeDistribution.java
@@ -1,0 +1,47 @@
+package me.sogom.bridge.domain.schedule.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.sogom.bridge.domain.common.BaseEntity;
+import me.sogom.bridge.domain.member.entity.Children;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.time.DayOfWeek;
+
+@Entity
+@Getter
+@EnableJpaAuditing
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "weekly_time_distributions")
+public class WeeklyTimeDistribution extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Children Entity import
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "child_id", nullable = false)
+    private Children child;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day_of_week", nullable = false)
+    private DayOfWeek dayOfWeek; // MONDAY, TUESDAY ... SUNDAY
+
+    @Column(name = "base_minutes", nullable = false)
+    private int baseMinutes; // 요일별 기본 세팅 시간 (분 단위)
+
+    @Builder
+    public WeeklyTimeDistribution(Children child, DayOfWeek dayOfWeek, int baseMinutes) {
+        this.child = child;
+        this.dayOfWeek = dayOfWeek;
+        this.baseMinutes = baseMinutes;
+    }
+
+    public void updateBaseMinutes(int minutes) {
+        this.baseMinutes = minutes;
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/repository/DailyTimeAllocationRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/repository/DailyTimeAllocationRepository.java
@@ -1,0 +1,19 @@
+package me.sogom.bridge.domain.schedule.repository;
+
+import me.sogom.bridge.domain.schedule.entity.DailyTimeAllocation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface DailyTimeAllocationRepository extends JpaRepository<DailyTimeAllocation, Long> {
+
+    // 특정 자녀의 '특정 날짜(오늘)' 데이터 단건 조회 (오늘 앱을 켤 때 가장 많이 쓰임!)
+    Optional<DailyTimeAllocation> findByChildIdAndTargetDate(Long childId, LocalDate targetDate);
+
+    // 특정 자녀의 '특정 기간(시작일~종료일)' 데이터 조회 (과거 사용 리포트나 주간 달력 뷰 그릴 때 유용)
+    List<DailyTimeAllocation> findAllByChildIdAndTargetDateBetween(Long childId, LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/repository/WeeklyBudgetRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/repository/WeeklyBudgetRepository.java
@@ -1,0 +1,15 @@
+package me.sogom.bridge.domain.schedule.repository;
+
+import me.sogom.bridge.domain.schedule.entity.WeeklyBudget;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WeeklyBudgetRepository extends JpaRepository<WeeklyBudget, Long> {
+    // 특정 월의 1~4주차 예산을 한 번에 조회
+    List<WeeklyBudget> findAllByChildIdAndYearMonth(Long childId, String yearMonth);
+
+    // 특정 월, 특정 주차의 예산 단건 조회
+    Optional<WeeklyBudget> findByChildIdAndYearMonthAndWeekNumber(Long childId, String yearMonth, int weekNumber);
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/repository/WeeklyRoutineRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/repository/WeeklyRoutineRepository.java
@@ -1,0 +1,10 @@
+package me.sogom.bridge.domain.schedule.repository;
+
+import me.sogom.bridge.domain.schedule.entity.WeeklyRoutine;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface WeeklyRoutineRepository extends JpaRepository<WeeklyRoutine, Long> {
+    // 특정 자녀의 일주일 전체 학원/고정 일정 조회
+    List<WeeklyRoutine> findAllByChild_Id(Long childId);
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/repository/WeeklyTimeDistributionRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/repository/WeeklyTimeDistributionRepository.java
@@ -16,4 +16,10 @@ public interface WeeklyTimeDistributionRepository extends JpaRepository<WeeklyTi
 
     // 특정 자녀의 '일주일치 전체' 템플릿 조회 (자녀가 주간 계획표 화면을 열었을 때 사용)
     List<WeeklyTimeDistribution> findAllByChildId(Long childId);
+
+    // 특정 주차의 월~일 설정 리스트 전체 조회
+    List<WeeklyTimeDistribution> findAllByChildIdAndYearMonthAndWeekNumber(Long childId, String yearMonth, int weekNumber);
+
+    // 특정 주차, 특정 요일의 단건 조회
+    Optional<WeeklyTimeDistribution> findByChildIdAndDayOfWeekAndYearMonthAndWeekNumber(Long childId, DayOfWeek dayOfWeek, String yearMonth, int weekNumber);
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/repository/WeeklyTimeDistributionRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/repository/WeeklyTimeDistributionRepository.java
@@ -1,0 +1,19 @@
+package me.sogom.bridge.domain.schedule.repository;
+
+import me.sogom.bridge.domain.schedule.entity.WeeklyTimeDistribution;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.DayOfWeek;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface WeeklyTimeDistributionRepository extends JpaRepository<WeeklyTimeDistribution, Long> {
+
+    // 특정 자녀의 '특정 요일' 템플릿 단건 조회 (오늘 요일 템플릿 꺼내올 때 사용)
+    Optional<WeeklyTimeDistribution> findByChildIdAndDayOfWeek(Long childId, DayOfWeek dayOfWeek);
+
+    // 특정 자녀의 '일주일치 전체' 템플릿 조회 (자녀가 주간 계획표 화면을 열었을 때 사용)
+    List<WeeklyTimeDistribution> findAllByChildId(Long childId);
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
@@ -125,4 +125,43 @@ public class ScheduleService {
         WeeklyRoutine routine = routineRepository.findById(routineId).orElseThrow();
         routineRepository.delete(routine);
     }
+    /**
+     하루 마무리 시 실제 사용 시간을 기록하고 남은 시간을 보상 풀로 환불하기
+     * @param actualUsedMinutes 자녀가 오늘 실제로 스마트폰을 사용한 시간 (분 단위)
+     */
+    @Transactional
+    public DailyTimeAllocation settleDailyTime(Long childId, LocalDate targetDate, int actualUsedMinutes) {
+
+        // 1. 오늘의 스케줄 배정 데이터 가져오기
+        DailyTimeAllocation allocation = dailyRepository.findByChildIdAndTargetDate(childId, targetDate)
+                .orElseThrow(() -> new IllegalArgumentException("오늘 생성된 시간표 데이터가 없습니다."));
+
+        // 오늘 자녀에게 주어졌던 총 가용 시간 계산 (기본시간 + 연장된시간)
+        int totalAllocatedTime = allocation.getTotalAvailableTime();
+
+        // 가드 로직: 혹시 실제 사용 시간이 준 시간보다 많으면 연산 오류이므로 방어
+        if (actualUsedMinutes > totalAllocatedTime) {
+            throw new IllegalArgumentException("실제 사용 시간이 할당된 총 시간을 초과할 수 없습니다.");
+        }
+
+        // 남은 시간 계산하기 (할당량 - 실제 사용량)
+        int unusedMinutes = totalAllocatedTime - actualUsedMinutes;
+
+        // 남은 시간이 존재한다면 부모 정책(TimePolicy) 데이터에 환불 절차 진행
+        if (unusedMinutes > 0) {
+            String yearMonth = targetDate.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+            TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책을 찾을 수 없습니다."));
+
+            // TimePolicy의 보상 풀에 남은 시간만큼 플러스(+) 처리
+            policy.refundUnusedTime(unusedMinutes);
+        }
+
+        // 오늘자 할당 기록의 baseMinutes와 extendedMinutes를 정산된 결과에 맞게 재조정
+        // 가장 깔끔한 방법은 오늘 가용시간 자체를 자녀가 실제 사용한 시간으로 락(Lock)을 걸어두는 것
+        // 다음 스케줄 조회 시 정산된 결과가 보이도록 엔티티 값을 세팅
+        allocation.updateToSettledTime(actualUsedMinutes);
+
+        return allocation;
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
@@ -1,0 +1,128 @@
+package me.sogom.bridge.domain.schedule.service;
+
+import lombok.RequiredArgsConstructor;
+import me.sogom.bridge.domain.member.entity.Children;
+import me.sogom.bridge.domain.member.repository.ChildrenRepository;
+import me.sogom.bridge.domain.policy.entity.TimePolicy;
+import me.sogom.bridge.domain.policy.repository.TimePolicyRepository;
+import me.sogom.bridge.domain.schedule.dto.RoutineRequest;
+import me.sogom.bridge.domain.schedule.dto.WeeklyTemplateRequest;
+import me.sogom.bridge.domain.schedule.entity.DailyTimeAllocation;
+import me.sogom.bridge.domain.schedule.entity.WeeklyRoutine;
+import me.sogom.bridge.domain.schedule.entity.WeeklyTimeDistribution;
+import me.sogom.bridge.domain.schedule.repository.DailyTimeAllocationRepository;
+import me.sogom.bridge.domain.schedule.repository.WeeklyRoutineRepository;
+import me.sogom.bridge.domain.schedule.repository.WeeklyTimeDistributionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleService {
+
+    private final WeeklyTimeDistributionRepository weeklyRepository;
+    private final DailyTimeAllocationRepository dailyRepository;
+    private final ChildrenRepository childrenRepository;
+    private final TimePolicyRepository timePolicyRepository;
+    private final WeeklyRoutineRepository routineRepository;
+
+    //오늘의 실제 제한 시간 조회 (없으면 요일 템플릿에서 동적 복사)
+    @Transactional
+    public DailyTimeAllocation getOrCreateDailyAllocation(Long childId, LocalDate targetDate) {
+        // 오늘 날짜의 데이터가 이미 있는지 DB에서 확인
+        return dailyRepository.findByChildIdAndTargetDate(childId, targetDate)
+                .orElseGet(() -> {
+                    // 없다면 오늘이 무슨 요일인지 확인
+                    DayOfWeek dayOfWeek = targetDate.getDayOfWeek();
+
+                    // 해당 요일의 '기본 템플릿(Weekly)'을 가져오기
+                    WeeklyTimeDistribution template = weeklyRepository.findByChildIdAndDayOfWeek(childId, dayOfWeek)
+                            .orElseThrow(() -> new IllegalArgumentException("해당 요일의 기본 시간표 설정이 없습니다."));
+
+                    // 자녀 엔티티 조회
+                    Children child = childrenRepository.findById(childId).orElseThrow();
+
+                    // 템플릿의 시간을 복사해서 '오늘(Daily)' 데이터를 새로 저장
+                    DailyTimeAllocation newAllocation = DailyTimeAllocation.builder()
+                            .child(child)
+                            .targetDate(targetDate)
+                            .baseMinutes(template.getBaseMinutes())
+                            .extendedMinutes(0) // 처음 생성될 때는 연장 시간이 0분
+                            .build();
+
+                    return dailyRepository.save(newAllocation);
+                });
+    }
+
+    //자녀가 여분(보상) 시간을 사용해 오늘 시간을 연장할 때
+    @Transactional
+    public DailyTimeAllocation extendDailyTime(Long childId, LocalDate targetDate, int extraMinutes) {
+
+        //날짜 변환 ("yyyy-MM" 형태)
+        String yearMonth = targetDate.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+
+        //DB에서 이번 달 부모 정책 정보 가져오기
+        TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
+                .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책이 설정되지 않았습니다."));
+
+        //엔티티의 차감 로직 호출 (알아서 기본시간->보상시간 순으로 깎고, 부족하면 에러를 던짐)
+        policy.deductAvailableTime(extraMinutes);
+
+        //오늘의 스케줄 데이터를 가져오기
+        DailyTimeAllocation allocation = getOrCreateDailyAllocation(childId, targetDate);
+
+        //오늘 스케줄에 시간을 연장하기
+        allocation.addExtraTime(extraMinutes);
+
+        return allocation;
+    }
+    //자녀가 최초/매주 요일별 기본 가용 시간(템플릿) 설정 및 수정
+    @Transactional
+    public void updateWeeklyTemplate(Long childId, WeeklyTemplateRequest request) {
+        WeeklyTimeDistribution weeklyDist = weeklyRepository.findByChildIdAndDayOfWeek(childId, request.getDayOfWeek())
+                .orElseGet(() -> {
+                    Children child = childrenRepository.findById(childId).orElseThrow();
+                    return WeeklyTimeDistribution.builder()
+                            .child(child)
+                            .dayOfWeek(request.getDayOfWeek())
+                            .build();
+                });
+
+        weeklyDist.updateBaseMinutes(request.getBaseMinutes());
+        weeklyRepository.save(weeklyDist);
+    }
+
+    //\학원/고정 일정(Routine) 등록
+    @Transactional
+    public void createRoutine(Long childId, RoutineRequest request) {
+        Children child = childrenRepository.findById(childId).orElseThrow();
+
+        WeeklyRoutine routine = WeeklyRoutine.builder()
+                .child(child)
+                .dayOfWeek(request.getDayOfWeek())
+                .startTime(request.getStartTime())
+                .endTime(request.getEndTime())
+                .title(request.getTitle())
+                .build();
+
+        routineRepository.save(routine);
+    }
+
+    //자녀의 주간 고정 일정 전체 조회 (시간표 조각들 목록)
+    @Transactional(readOnly = true)
+    public List<WeeklyRoutine> getWeeklyRoutines(Long childId) {
+        return routineRepository.findAllByChild_Id(childId);
+    }
+
+    //고정 일정 삭제
+    @Transactional
+    public void deleteRoutine(Long routineId) {
+        WeeklyRoutine routine = routineRepository.findById(routineId).orElseThrow();
+        routineRepository.delete(routine);
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
@@ -6,11 +6,14 @@ import me.sogom.bridge.domain.member.repository.ChildrenRepository;
 import me.sogom.bridge.domain.policy.entity.TimePolicy;
 import me.sogom.bridge.domain.policy.repository.TimePolicyRepository;
 import me.sogom.bridge.domain.schedule.dto.RoutineRequest;
+import me.sogom.bridge.domain.schedule.dto.WeeklyBudgetRequest;
 import me.sogom.bridge.domain.schedule.dto.WeeklyTemplateRequest;
 import me.sogom.bridge.domain.schedule.entity.DailyTimeAllocation;
+import me.sogom.bridge.domain.schedule.entity.WeeklyBudget;
 import me.sogom.bridge.domain.schedule.entity.WeeklyRoutine;
 import me.sogom.bridge.domain.schedule.entity.WeeklyTimeDistribution;
 import me.sogom.bridge.domain.schedule.repository.DailyTimeAllocationRepository;
+import me.sogom.bridge.domain.schedule.repository.WeeklyBudgetRepository;
 import me.sogom.bridge.domain.schedule.repository.WeeklyRoutineRepository;
 import me.sogom.bridge.domain.schedule.repository.WeeklyTimeDistributionRepository;
 import org.springframework.stereotype.Service;
@@ -30,6 +33,7 @@ public class ScheduleService {
     private final ChildrenRepository childrenRepository;
     private final TimePolicyRepository timePolicyRepository;
     private final WeeklyRoutineRepository routineRepository;
+    private final WeeklyBudgetRepository weeklyBudgetRepository;
 
     //오늘의 실제 제한 시간 조회 (없으면 요일 템플릿에서 동적 복사)
     @Transactional
@@ -96,36 +100,39 @@ public class ScheduleService {
     //요일별 기본 템플릿 설정 초과 등록 버그 수정
     @Transactional
     public void updateWeeklyTemplate(Long childId, WeeklyTemplateRequest request) {
-        String yearMonth = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
-        TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
-                .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책이 설정되지 않았습니다."));
+        // 해당 월/주차에 자녀가 설정해둔 예산(WeeklyBudget) 가져오기
+        WeeklyBudget weeklyBudget = weeklyBudgetRepository.findByChildIdAndYearMonthAndWeekNumber(
+                        childId, request.getYearMonth(), request.getWeekNumber())
+                .orElseThrow(() -> new IllegalArgumentException(request.getWeekNumber() + "주차의 예산이 설정되지 않았습니다. 주차별 예산을 먼저 분배해주세요."));
 
-        //현재 DB에 저장되어 있는 이 자녀의 월~일 전체 기본 틀 시간의 합을 구함
-        List<WeeklyTimeDistribution> allTemplates = weeklyRepository.findAllByChildId(childId);
+        // 해당 주차에 이미 등록된 월~일 템플릿 시간의 합 구하기
+        List<WeeklyTimeDistribution> weekTemplates = weeklyRepository.findAllByChildIdAndYearMonthAndWeekNumber(
+                childId, request.getYearMonth(), request.getWeekNumber());
 
-        int currentWeeklySum = allTemplates.stream()
-                // 지금 수정하려는 요일의 기존 시간은 제외하고 나머지 요일들만 합산
-                .filter(t -> !t.getDayOfWeek().equals(request.getDayOfWeek()))
+        int currentSum = weekTemplates.stream()
+                .filter(t -> !t.getDayOfWeek().equals(request.getDayOfWeek())) // 지금 설정하려는 요일은 제외하고 합산
                 .mapToInt(WeeklyTimeDistribution::getBaseMinutes)
                 .sum();
 
-        //여기에 새로 등록/수정하려는 요일의 시간을 더해봄
-        int expectedWeeklySum = currentWeeklySum + request.getBaseMinutes();
+        int expectedSum = currentSum + request.getBaseMinutes();
 
-        // 일주일 기본 틀의 합이 부모 저금통의 한도를 초과하면 즉시 차단!
-        if (expectedWeeklySum > policy.getBaseTime()) {
-            throw new IllegalArgumentException("주간 시간표의 총합(" + expectedWeeklySum + "분)이 부모님이 설정한 이번 달 총 가용 시간(" + policy.getBaseTime() + "분)을 초과할 수 없습니다!");
+        // 요일 합계가 '해당 주차의 예산'을 넘는지 검증
+        if (expectedSum > weeklyBudget.getAllocatedMinutes()) {
+            throw new IllegalArgumentException(request.getWeekNumber() + "주차의 설정 총합(" + expectedSum + "분)이 이번 주 예산(" + weeklyBudget.getAllocatedMinutes() + "분)을 초과할 수 없습니다.");
         }
 
-        // 안전함이 검증되었을 때만 DB에 반영
-        WeeklyTimeDistribution weeklyDist = weeklyRepository.findByChildIdAndDayOfWeek(childId, request.getDayOfWeek())
+        // 검증 통과 시 DB에 저장 (또는 기존 데이터 업데이트)
+        WeeklyTimeDistribution template = weeklyRepository.findByChildIdAndDayOfWeekAndYearMonthAndWeekNumber(
+                        childId, request.getDayOfWeek(), request.getYearMonth(), request.getWeekNumber())
                 .orElseGet(() -> WeeklyTimeDistribution.builder()
-                        .child(policy.getChild())
+                        .child(weeklyBudget.getChild())
+                        .yearMonth(request.getYearMonth())
+                        .weekNumber(request.getWeekNumber())
                         .dayOfWeek(request.getDayOfWeek())
                         .build());
 
-        weeklyDist.updateBaseMinutes(request.getBaseMinutes());
-        weeklyRepository.save(weeklyDist);
+        template.updateBaseMinutes(request.getBaseMinutes());
+        weeklyRepository.save(template);
     }
 
     //\학원/고정 일정(Routine) 등록
@@ -194,5 +201,37 @@ public class ScheduleService {
         allocation.updateToSettledTime(actualUsedMinutes);
 
         return allocation;
+    }
+    @Transactional
+    public void createWeeklyBudgets(Long childId, String yearMonth, List<WeeklyBudgetRequest> requests) {
+// 1. 부모가 설정한 이번 달 총 가용 시간 조회
+        TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
+                .orElseThrow(() -> new IllegalArgumentException("정책이 없습니다."));
+
+// 2. 자녀가 요청한 1~4주차 시간의 총합 계산
+        int totalRequestedMinutes = requests.stream()
+                .mapToInt(WeeklyBudgetRequest::getAllocatedMinutes)
+                .sum();
+
+// 3. 한 달 총량을 초과하는지 검증
+        if (totalRequestedMinutes > policy.getBaseTime()) {
+            throw new IllegalArgumentException("주차별 분배 시간의 합이 한 달 총량을 초과할 수 없습니다.");
+        }
+
+// 4. 기존 데이터가 있다면 삭제 후 새로 저장 (또는 update 처리)
+        weeklyBudgetRepository.deleteAll(weeklyBudgetRepository.findAllByChildIdAndYearMonth(childId, yearMonth));
+
+        Children child = childrenRepository.findById(childId).orElseThrow();
+
+        List<WeeklyBudget> budgets = requests.stream()
+                .map(req -> WeeklyBudget.builder()
+                        .child(child)
+                        .yearMonth(yearMonth)
+                        .weekNumber(req.getWeekNumber())
+                        .allocatedMinutes(req.getAllocatedMinutes())
+                        .build())
+                .toList();
+
+        weeklyBudgetRepository.saveAll(budgets);
     }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
@@ -82,16 +82,36 @@ public class ScheduleService {
         return allocation;
     }
     //자녀가 최초/매주 요일별 기본 가용 시간(템플릿) 설정 및 수정
+    //요일별 기본 템플릿 설정 초과 등록 버그 수정
     @Transactional
     public void updateWeeklyTemplate(Long childId, WeeklyTemplateRequest request) {
+        String yearMonth = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM"));
+        TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
+                .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책이 설정되지 않았습니다."));
+
+        //현재 DB에 저장되어 있는 이 자녀의 월~일 전체 기본 틀 시간의 합을 구함
+        List<WeeklyTimeDistribution> allTemplates = weeklyRepository.findAllByChildId(childId);
+
+        int currentWeeklySum = allTemplates.stream()
+                // 지금 수정하려는 요일의 기존 시간은 제외하고 나머지 요일들만 합산
+                .filter(t -> !t.getDayOfWeek().equals(request.getDayOfWeek()))
+                .mapToInt(WeeklyTimeDistribution::getBaseMinutes)
+                .sum();
+
+        //여기에 새로 등록/수정하려는 요일의 시간을 더해봄
+        int expectedWeeklySum = currentWeeklySum + request.getBaseMinutes();
+
+        // 일주일 기본 틀의 합이 부모 저금통의 한도를 초과하면 즉시 차단!
+        if (expectedWeeklySum > policy.getBaseTime()) {
+            throw new IllegalArgumentException("주간 시간표의 총합(" + expectedWeeklySum + "분)이 부모님이 설정한 이번 달 총 가용 시간(" + policy.getBaseTime() + "분)을 초과할 수 없습니다!");
+        }
+
+        // 안전함이 검증되었을 때만 DB에 반영
         WeeklyTimeDistribution weeklyDist = weeklyRepository.findByChildIdAndDayOfWeek(childId, request.getDayOfWeek())
-                .orElseGet(() -> {
-                    Children child = childrenRepository.findById(childId).orElseThrow();
-                    return WeeklyTimeDistribution.builder()
-                            .child(child)
-                            .dayOfWeek(request.getDayOfWeek())
-                            .build();
-                });
+                .orElseGet(() -> WeeklyTimeDistribution.builder()
+                        .child(policy.getChild())
+                        .dayOfWeek(request.getDayOfWeek())
+                        .build());
 
         weeklyDist.updateBaseMinutes(request.getBaseMinutes());
         weeklyRepository.save(weeklyDist);

--- a/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
@@ -44,6 +44,17 @@ public class ScheduleService {
                     WeeklyTimeDistribution template = weeklyRepository.findByChildIdAndDayOfWeek(childId, dayOfWeek)
                             .orElseThrow(() -> new IllegalArgumentException("해당 요일의 기본 시간표 설정이 없습니다."));
 
+                    // 이번 달 부모 정책 가져오기
+                    String yearMonth = targetDate.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+                    TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
+                            .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책이 설정되지 않았습니다."));
+
+                    // 템플릿에 설정된 설정 시간만큼 기본 시간에서 선차감 진행
+                    policy.deductAvailableTime(template.getBaseMinutes());
+
+                    // 변경된 상태를 DB에 확실하게 즉시 업데이트(UPDATE)
+                    timePolicyRepository.save(policy);
+
                     // 자녀 엔티티 조회
                     Children child = childrenRepository.findById(childId).orElseThrow();
 

--- a/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
@@ -138,7 +138,7 @@ public class ScheduleService {
                 .dayOfWeek(request.getDayOfWeek())
                 .startTime(request.getStartTime())
                 .endTime(request.getEndTime())
-                .title(request.getTitle())
+                .title("고정 시간") // 프론트에서 받지 않고 서버에서 기본값 할당
                 .build();
 
         routineRepository.save(routine);


### PR DESCRIPTION
## 작업 내용

한 달 가용 시간(TimePolicy)을 1~4주차 예산으로 분할 설정하는 WeeklyBudget 엔티티 및 저장 로직 추가

주차별 예산을 기준으로 요일별 스케줄 시간 합산을 제한하는 WeeklyTimeDistribution 검증 가드 구현

당일 시간표 최초 접속 시 동적 생성 및 부모 기본 제공 시간에서의 선차감 메커니즘 연동

 RoutineRequest DTO 필드 구조 개편 및 응답 DTO 수정

이 외 #29 에 기록되어 있는 사항들 구현

## 테스트
주차별 예산 분배 시 부모의 월간 한도를 초과할 경우 예외 발생 및 차단 확인

요일별 시간 등록 시 해당 주차의 설정 예산을 초과할 경우 예외 발생 및 차단 확인

데이터베이스(PostgreSQL) 콘솔을 통한 WeeklyTimeDistribution 테이블 신규 컬럼(year_month, week_number) 정상 매핑 및 갱신 내역 교차 검증

관련 이슈
- Closes https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/28
- Relates to https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/28