### PR TITLE
Feat: 자녀별 미션 생성 및 조회 구현

### DIFF
--- a/src/main/java/me/sogom/bridge/BridgeApplication.java
+++ b/src/main/java/me/sogom/bridge/BridgeApplication.java
@@ -3,9 +3,11 @@ package me.sogom.bridge;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class BridgeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/me/sogom/bridge/domain/mission/code/MissionSuccessCode.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/code/MissionSuccessCode.java
@@ -1,0 +1,17 @@
+package me.sogom.bridge.domain.mission.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import me.sogom.bridge.global.apiPayload.code.BaseSuccessCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MissionSuccessCode implements BaseSuccessCode {
+
+    MISSION_CREATE_SUCCESS(HttpStatus.CREATED, "MISSION201_CREATE", "미션 등록에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/code/MissionSuccessCode.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/code/MissionSuccessCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MissionSuccessCode implements BaseSuccessCode {
 
-    MISSION_CREATE_SUCCESS(HttpStatus.CREATED, "MISSION201_CREATE", "미션 등록에 성공했습니다.");
+    MISSION_CREATE_SUCCESS(HttpStatus.CREATED, "MISSION201_CREATE", "미션 등록에 성공했습니다."),
+    MISSION_LIST_SUCCESS(HttpStatus.OK, "MISSION200", "자녀 미션 조회에 성공했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
@@ -1,11 +1,18 @@
 package me.sogom.bridge.domain.mission.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import me.sogom.bridge.domain.mission.code.MissionSuccessCode;
 import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
+import me.sogom.bridge.domain.mission.dto.req.MissionReqDTO;
+import me.sogom.bridge.domain.mission.dto.res.MissionResDTO;
 import me.sogom.bridge.domain.mission.service.MissionPerformanceService; // 변경: 통합 서비스 임포트
+import me.sogom.bridge.domain.mission.service.MissionService;
 import me.sogom.bridge.global.apiPayload.ApiResponse;
 import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
+import me.sogom.bridge.global.security.entity.AuthMember;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*; // PathVariable 등을 위해 추가
 import org.springframework.web.multipart.MultipartFile;
 
@@ -18,6 +25,18 @@ public class MissionController {
 
     // 변경: AI 전담 서비스 대신, DB 저장까지 책임지는 MissionPerformanceService를 주입
     private final MissionPerformanceService performanceService;
+    private final MissionService missionService;
+
+    //부모의 미션 등록 API
+    @PostMapping
+    public ApiResponse<MissionResDTO.CreateMissionResponse> createMission(
+            @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody @Valid MissionReqDTO.CreateMissionRequest request) {
+
+        Long parentId = authMember.asParent().getId();
+        MissionResDTO.CreateMissionResponse response = missionService.createMission(parentId, request);
+        return ApiResponse.onSuccess(MissionSuccessCode.MISSION_CREATE_SUCCESS, response);
+    }
 
     //자녀의 미션 수행 인증 API
     @PostMapping(value = "/{missionId}/performances", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -29,7 +48,7 @@ public class MissionController {
 
         // Service에서 권한 검증 -> AI 판독 -> DB 저장(reason 포함)을 한 번에 처리 후 결과 반환
         AiVerificationResponse result = performanceService.verifyAndSaveMission(missionId, childId, image, prompt);
-        
+
         // APIResponse 포맷으로 반환
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, result);
     }

--- a/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.*; // PathVariable 등을 위해 
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/missions")
@@ -37,6 +38,17 @@ public class MissionController {
         Long parentId = authMember.asParent().getId();
         MissionResDTO.CreateMissionResponse response = missionService.createMission(parentId, request);
         return ApiResponse.onSuccess(MissionSuccessCode.MISSION_CREATE_SUCCESS, response);
+    }
+
+    //부모의 미션 목록 조회 API
+    @GetMapping
+    public ApiResponse<List<MissionResDTO.MissionSummaryResponse>> getMissionList(
+            @AuthenticationPrincipal AuthMember authMember,
+            @RequestParam("childId") Long childId) {
+
+        Long parentId = authMember.asParent().getId();
+        List<MissionResDTO.MissionSummaryResponse> response = missionService.getParentMissionSummaries(parentId, childId);
+        return ApiResponse.onSuccess(MissionSuccessCode.MISSION_LIST_SUCCESS, response);
     }
 
     //자녀의 미션 수행 인증 API

--- a/src/main/java/me/sogom/bridge/domain/mission/dto/req/MissionReqDTO.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/dto/req/MissionReqDTO.java
@@ -1,0 +1,38 @@
+package me.sogom.bridge.domain.mission.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import me.sogom.bridge.domain.mission.entity.MissionCategory;
+import me.sogom.bridge.domain.mission.entity.ResetCycle;
+import me.sogom.bridge.domain.mission.entity.VerificationType;
+
+public class MissionReqDTO {
+
+    public record CreateMissionRequest(
+
+            @NotNull(message = "자녀 ID를 입력해 주세요.")
+            Long childId,
+
+            @NotBlank(message = "미션 이름을 입력해 주세요.")
+            @Size(max = 50, message = "미션 이름은 50자 이하로 입력해 주세요.")
+            String title,
+
+            @NotNull(message = "카테고리를 선택해 주세요.")
+            MissionCategory category,
+
+            @NotNull(message = "리셋 주기를 선택해 주세요.")
+            ResetCycle resetCycle,
+
+            @NotNull(message = "확인 방식을 선택해 주세요.")
+            VerificationType verificationType,
+
+            @NotNull(message = "지급 시간을 입력해 주세요.")
+            @PositiveOrZero(message = "지급 시간은 0 이상이어야 합니다.")
+            Integer reward,
+
+            @Size(max = 500, message = "상세 설명은 500자 이하로 입력해 주세요.")
+            String description
+    ) {}
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/dto/res/MissionResDTO.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/dto/res/MissionResDTO.java
@@ -1,0 +1,36 @@
+package me.sogom.bridge.domain.mission.dto.res;
+
+import lombok.Builder;
+import me.sogom.bridge.domain.mission.entity.Mission;
+import me.sogom.bridge.domain.mission.entity.MissionCategory;
+import me.sogom.bridge.domain.mission.entity.MissionSetting;
+import me.sogom.bridge.domain.mission.entity.ResetCycle;
+import me.sogom.bridge.domain.mission.entity.VerificationType;
+
+public class MissionResDTO {
+
+    @Builder
+    public record CreateMissionResponse(
+            Long missionId,
+            Long childId,
+            String title,
+            MissionCategory category,
+            ResetCycle resetCycle,
+            VerificationType verificationType,
+            int reward,
+            String description
+    ) {
+        public static CreateMissionResponse of(Mission mission, MissionSetting setting) {
+            return CreateMissionResponse.builder()
+                    .missionId(mission.getId())
+                    .childId(mission.getChild().getId())
+                    .title(mission.getTitle())
+                    .category(setting.getCategory())
+                    .resetCycle(setting.getResetCycle())
+                    .verificationType(setting.getVerificationType())
+                    .reward(setting.getReward())
+                    .description(setting.getDescription())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/dto/res/MissionResDTO.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/dto/res/MissionResDTO.java
@@ -33,4 +33,13 @@ public class MissionResDTO {
                     .build();
         }
     }
+
+
+    public record MissionSummaryResponse(
+            Long missionId,
+            String title,
+            MissionCategory category,
+            int reward
+    ) {
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/entity/Mission.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/entity/Mission.java
@@ -2,6 +2,8 @@ package me.sogom.bridge.domain.mission.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import me.sogom.bridge.domain.common.BaseEntity;
@@ -10,6 +12,8 @@ import me.sogom.bridge.domain.member.entity.Parent;
 //mission entity
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "mission")
 public class Mission extends BaseEntity {

--- a/src/main/java/me/sogom/bridge/domain/mission/entity/MissionSetting.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/entity/MissionSetting.java
@@ -2,27 +2,54 @@ package me.sogom.bridge.domain.mission.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 //mission setting entity
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "mission_setting")
 public class MissionSetting {
     @Id
     @Column(name = "mission_setting_id")
-    private String id; // SQL에 BIGINT가 아닌 VARCHAR(255)로 되어 있음
+    private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "mission_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id", nullable = false, unique = true)
     private Mission mission;
 
     @Enumerated(EnumType.STRING)
-    private MissionCategory category; // ENUM 클래스
+    @Column(nullable = false)
+    private MissionCategory category;
 
-    private int reward; // 보상 시간
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reset_cycle", nullable = false)
+    private ResetCycle resetCycle; // 미션 초기화 주기 (DAILY, WEEKLY, MONTHLY)
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "verification_type", nullable = false)
+    private VerificationType verificationType; // 확인 방식 (AI, CHILD, PARENT)
+
+    @Column(nullable = false)
+    private int reward; // 지급 시간 (분)
+
+    @Column(length = 500)
+    private String description; // 미션 상세 설명
 
     @Column(length = 100)
     private String prompt; // 부모가 작성한 AI 검증 기준
+
+    @Column(name = "last_reset_at", nullable = false)
+    private LocalDateTime lastResetAt;
+
+
+    public void markReset(LocalDateTime resetAt) {
+        this.lastResetAt = resetAt;
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/entity/MissionSetting.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/entity/MissionSetting.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 @Table(name = "mission_setting")
 public class MissionSetting {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "mission_setting_id")
     private Long id;
 

--- a/src/main/java/me/sogom/bridge/domain/mission/entity/ResetCycle.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/entity/ResetCycle.java
@@ -1,0 +1,17 @@
+package me.sogom.bridge.domain.mission.entity;
+
+import java.time.LocalDateTime;
+
+public enum ResetCycle {
+    DAILY,
+    WEEKLY,
+    MONTHLY;
+
+    public LocalDateTime nextResetAfter(LocalDateTime from) {
+        return switch (this) {
+            case DAILY -> from.plusDays(1);
+            case WEEKLY -> from.plusWeeks(1);
+            case MONTHLY -> from.plusMonths(1);
+        };
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/entity/VerificationType.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/entity/VerificationType.java
@@ -1,0 +1,7 @@
+package me.sogom.bridge.domain.mission.entity;
+
+public enum VerificationType {
+    AI,
+    CHILD,
+    PARENT
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/exception/MissionErrorCode.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/exception/MissionErrorCode.java
@@ -11,7 +11,8 @@ public enum MissionErrorCode implements BaseErrorCode {
 
     MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION404", "해당 미션을 찾을 수 없습니다."),
     AI_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MISSION500", "AI 판독 결과를 처리하는 중 오류가 발생했습니다."),
-    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "MISSION403", "해당 미션에 대한 수행 권한이 없습니다."); //권한 검증 실패 시 사용
+    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "MISSION403", "해당 미션에 대한 수행 권한이 없습니다."), //권한 검증 실패 시 사용
+    CHILD_PARENT_MISMATCH(HttpStatus.FORBIDDEN, "MISSION403_CHILD", "해당 자녀에게 미션을 부여할 권한이 없습니다.");
     // 필요할 때마다 여기에 추가 예정
 
     private final HttpStatus status;

--- a/src/main/java/me/sogom/bridge/domain/mission/repository/MissionSettingRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/repository/MissionSettingRepository.java
@@ -1,0 +1,7 @@
+package me.sogom.bridge.domain.mission.repository;
+
+import me.sogom.bridge.domain.mission.entity.MissionSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MissionSettingRepository extends JpaRepository<MissionSetting, String> {
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/repository/MissionSettingRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/repository/MissionSettingRepository.java
@@ -1,10 +1,29 @@
 package me.sogom.bridge.domain.mission.repository;
 
+import me.sogom.bridge.domain.mission.dto.res.MissionResDTO;
 import me.sogom.bridge.domain.mission.entity.MissionSetting;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 import java.util.Optional;
 
-public interface MissionSettingRepository extends JpaRepository<MissionSetting, String> {
+public interface MissionSettingRepository extends JpaRepository<MissionSetting, Long> {
     // 미션 ID로 세팅 정보(reward가 포함된)를 조회하는 메서드
     Optional<MissionSetting> findByMissionId(Long missionId);
+
+    @Query("""
+            select new me.sogom.bridge.domain.mission.dto.res.MissionResDTO$MissionSummaryResponse(
+                m.id,
+                m.title,
+                s.category,
+                s.reward
+            )
+            from MissionSetting s
+            join s.mission m
+            where m.parent.id = :parentId
+              and m.child.id = :childId
+            order by m.id desc
+            """)
+    List<MissionResDTO.MissionSummaryResponse> findMissionSummariesByParentIdAndChildId(Long parentId, Long childId);
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/scheduler/MissionResetScheduler.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/scheduler/MissionResetScheduler.java
@@ -1,0 +1,41 @@
+package me.sogom.bridge.domain.mission.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.sogom.bridge.domain.mission.entity.MissionSetting;
+import me.sogom.bridge.domain.mission.repository.MissionSettingRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/*
+ 리셋 주기에 따라 미션 상태를 초기화
+ 주기가 경과하면 lastResetAt을 현재 시각으로 갱신해 미션 재오픈
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MissionResetScheduler {
+
+    private final MissionSettingRepository missionSettingRepository;
+
+    @Scheduled(cron = "0 5 0 * * *")
+    @Transactional
+    public void resetMissions() {
+        LocalDateTime now = LocalDateTime.now();
+        List<MissionSetting> settings = missionSettingRepository.findAll();
+
+        int resetCount = 0;
+        for (MissionSetting setting : settings) {
+            LocalDateTime nextReset = setting.getResetCycle().nextResetAfter(setting.getLastResetAt());
+            if (!now.isBefore(nextReset)) {
+                setting.markReset(now);
+                resetCount++;
+            }
+        }
+        log.info("MissionResetScheduler: {}건 미션 리셋 완료 (총 {}건 검사)", resetCount, settings.size());
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionService.java
@@ -1,0 +1,66 @@
+package me.sogom.bridge.domain.mission.service;
+
+import lombok.RequiredArgsConstructor;
+import me.sogom.bridge.domain.member.MemberException;
+import me.sogom.bridge.domain.member.code.MemberErrorCode;
+import me.sogom.bridge.domain.member.entity.Children;
+import me.sogom.bridge.domain.member.entity.Parent;
+import me.sogom.bridge.domain.member.repository.ChildrenRepository;
+import me.sogom.bridge.domain.member.repository.ParentRepository;
+import me.sogom.bridge.domain.mission.dto.req.MissionReqDTO;
+import me.sogom.bridge.domain.mission.dto.res.MissionResDTO;
+import me.sogom.bridge.domain.mission.entity.Mission;
+import me.sogom.bridge.domain.mission.entity.MissionSetting;
+import me.sogom.bridge.domain.mission.exception.MissionErrorCode;
+import me.sogom.bridge.domain.mission.exception.MissionException;
+import me.sogom.bridge.domain.mission.repository.MissionRepository;
+import me.sogom.bridge.domain.mission.repository.MissionSettingRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class MissionService {
+
+    private final MissionRepository missionRepository;
+    private final MissionSettingRepository missionSettingRepository;
+    private final ParentRepository parentRepository;
+    private final ChildrenRepository childrenRepository;
+
+    @Transactional
+    public MissionResDTO.CreateMissionResponse createMission(Long parentId, MissionReqDTO.CreateMissionRequest request) {
+
+        Parent parent = parentRepository.findById(parentId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        Children child = childrenRepository.findById(request.childId())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.CHILDREN_NOT_FOUND));
+
+        // 부모-자녀 연관관계 검증
+        if (child.getParent() == null || !child.getParent().getId().equals(parentId)) {
+            throw new MissionException(MissionErrorCode.CHILD_PARENT_MISMATCH);
+        }
+
+        Mission mission = Mission.builder()
+                .parent(parent)
+                .child(child)
+                .title(request.title())
+                .build();
+        missionRepository.save(mission);
+
+        MissionSetting setting = MissionSetting.builder()
+                .mission(mission)
+                .category(request.category())
+                .resetCycle(request.resetCycle())
+                .verificationType(request.verificationType())
+                .reward(request.reward())
+                .description(request.description())
+                .lastResetAt(LocalDateTime.now())
+                .build();
+        missionSettingRepository.save(setting);
+
+        return MissionResDTO.CreateMissionResponse.of(mission, setting);
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -62,5 +63,20 @@ public class MissionService {
         missionSettingRepository.save(setting);
 
         return MissionResDTO.CreateMissionResponse.of(mission, setting);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MissionResDTO.MissionSummaryResponse> getParentMissionSummaries(Long parentId, Long childId) {
+        parentRepository.findById(parentId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        Children child = childrenRepository.findById(childId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.CHILDREN_NOT_FOUND));
+
+        if (child.getParent() == null || !child.getParent().getId().equals(parentId)) {
+            throw new MissionException(MissionErrorCode.CHILD_PARENT_MISMATCH);
+        }
+
+        return missionSettingRepository.findMissionSummariesByParentIdAndChildId(parentId, childId);
     }
 }


### PR DESCRIPTION
## 주요 변경 사항

-  자녀 미션 생성
- 리셋주기에 따른 미션 상태 초기화 스케쥴러
- 자녀별 미션리스트 조회

## 관련 이슈/마일스톤

<!-- Close 키워드로 연결하면 머지 시 자동 종료됩니다. -->

<!-- 예: Closes #1, Relates to #2 / Milestone: 2025-12 Sprint 4 -->

- Closes #23 
- Relates to #23 