### PR TITLE
Feat: 미션 인증 방식 추가 (부모, 자식 확인)

### DIFF
--- a/src/main/java/me/sogom/bridge/domain/member/code/MemberErrorCode.java
+++ b/src/main/java/me/sogom/bridge/domain/member/code/MemberErrorCode.java
@@ -18,7 +18,7 @@ public enum MemberErrorCode implements BaseErrorCode {
     CHILDREN_ALREADY_REGISTERED(HttpStatus.CONFLICT, "MEMBER409_CHILDREN", "이미 다른 부모와 연결된 자녀입니다."),
     PASSWORD_SAME_AS_OLD(HttpStatus.CONFLICT, "MEMBER409_PASSWORD_SAME", "새 비밀번호가 기존 비밀번호와 동일합니다."),
     PASSWORD_CHANGE_TOO_SOON(HttpStatus.TOO_MANY_REQUESTS, "MEMBER429_PASSWORD", "비밀번호는 24시간 내에 최대 1회만 변경할 수 있습니다."),
-    MEMBER_INACTIVE(HttpStatus.FORBIDDEN, "MEMBER403_INACTIVE", "비활성화된 계정입니다.");
+    MEMBER_INACTIVE(HttpStatus.FORBIDDEN, "MEMBER403_INACTIVE", "비활성화된 계정입니다."),
     CHILDREN_PARENT_MISMATCH(HttpStatus.UNAUTHORIZED, "MEMBER401_CHILDREN", "자녀와 부모의 연결이 올바르지 않습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/me/sogom/bridge/domain/member/code/MemberSuccessCode.java
+++ b/src/main/java/me/sogom/bridge/domain/member/code/MemberSuccessCode.java
@@ -18,7 +18,7 @@ public enum MemberSuccessCode implements BaseSuccessCode {
     CHILDREN_REGISTER_SUCCESS(HttpStatus.CREATED, "MEMBER201_CHILDREN_REGISTER", "자녀 등록에 성공했습니다."),
     CHILDREN_LIST_SUCCESS(HttpStatus.OK, "MEMBER200_CHILDREN_LIST", "자녀 목록 조회에 성공했습니다."),
     PASSWORD_CHANGE_SUCCESS(HttpStatus.OK, "MEMBER200_PASSWORD_CHANGE", "비밀번호 변경에 성공했습니다."),
-    MEMBER_WITHDRAW_SUCCESS(HttpStatus.OK, "MEMBER200_WITHDRAW", "회원 탈퇴에 성공했습니다.");
+    MEMBER_WITHDRAW_SUCCESS(HttpStatus.OK, "MEMBER200_WITHDRAW", "회원 탈퇴에 성공했습니다."),
     TIME_POLICY_SET_SUCCESS(HttpStatus.CREATED, "MEMBER201_TIME_POLICY_SET", "자녀 총시간 설정에 성공했습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
@@ -86,4 +86,37 @@ public class MissionController {
         MissionPerformanceResDTO.MissionPerformanceResponse response = performanceService.getMissionPerformance(missionId, parentId);
         return ApiResponse.onSuccess(MissionSuccessCode.MISSION_PERFORMANCE_RETRIEVE_SUCCESS, response);
     }
+
+    // 부모의 미션 승인 API
+    @PatchMapping("/performances/{performanceId}/approve")
+    public ApiResponse<String> approveMission(
+            @PathVariable Long performanceId,
+            @AuthenticationPrincipal AuthMember authMember) {
+
+        Long parentId = authMember.asParent().getId();
+
+        performanceService.approveMission(performanceId, parentId);
+
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                "미션 승인 완료"
+        );
+    }
+
+    // 부모의 미션 거절 API
+    @PatchMapping("/performances/{performanceId}/reject")
+    public ApiResponse<String> rejectMission(
+            @PathVariable Long performanceId,
+            @AuthenticationPrincipal AuthMember authMember) {
+
+        Long parentId = authMember.asParent().getId();
+
+        performanceService.rejectMission(performanceId, parentId);
+
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                "미션 거절 완료"
+        );
+    }
+
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
@@ -64,6 +64,62 @@ public class MissionPerformanceService {
                 .build();
         performanceRepository.save(performance);
 
+        // 미션 설정 정보 조회
+        MissionSetting setting = missionSettingRepository.findByMissionId(missionId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
+
+        // 미션 인증 방식 조회
+        VerificationType verificationType = setting.getVerificationType();
+
+        // 부모 확인 방식인 경우 부모 승인 대기 상태로 유지
+        if (verificationType == VerificationType.PARENT) {
+
+            performance.updateStatusAndReason(
+                    MissionStatus.PENDING,
+                    "부모님 확인 대기중입니다."
+            );
+
+            performanceRepository.save(performance);
+
+            return new AiVerificationResponse(
+                    false,
+                    "부모님 확인 대기중입니다."
+            );
+        }
+
+        // 자녀 확인 방식인 경우 즉시 승인 처리
+        if (verificationType == VerificationType.CHILD) {
+
+            performance.updateStatusAndReason(
+                    MissionStatus.ACCEPTED,
+                    "자녀 확인 방식으로 승인되었습니다."
+            );
+
+            // 해당 미션에 걸려있는 보상 시간 조회
+            int rewardTime = setting.getReward();
+
+            // 현재 날짜 기준 년월 조회
+            String currentYearMonth = YearMonth.now().toString();
+
+            // 자녀의 이번 달 시간 정책 조회
+            TimePolicy timePolicy = timePolicyRepository
+                    .findByChildIdAndYearMonth(childId, currentYearMonth)
+                    .orElseThrow(() ->
+                            new IllegalArgumentException("이번 달에 설정된 자녀의 시간 정책(TimePolicy)이 없습니다."));
+
+            // 보상 시간 지급
+            timePolicy.addReward(rewardTime);
+
+            timePolicyRepository.save(timePolicy);
+
+            performanceRepository.save(performance);
+
+            return new AiVerificationResponse(
+                    true,
+                    "미션 완료로 보상 시간이 지급되었습니다."
+            );
+        }
+
         // try-catch 블록 내부와 외부 모두에서 사용하기 위해 변수를 미리 선언합니다.
         AiVerificationResponse aiResponse;
 
@@ -80,8 +136,7 @@ public class MissionPerformanceService {
             // 미션 판독 결과가 성공(ACCEPTED)일 때만 실시간 보상 시간 정산 진행
             if (finalStatus == MissionStatus.ACCEPTED) {
                 // 해당 미션에 걸려있는 보상 시간(reward) 가져오기
-                MissionSetting setting = missionSettingRepository.findByMissionId(missionId)
-                        .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
+
                 int rewardTime = setting.getReward();
 
                 // 현재 날짜 기준 년월 구하기 (예: "2026-05")
@@ -128,4 +183,80 @@ public class MissionPerformanceService {
 
         return MissionPerformanceResDTO.MissionPerformanceResponse.of(performance);
     }
+
+    @Transactional
+    public void approveMission(Long performanceId, Long parentId) {
+
+        MissionPerformance performance = performanceRepository.findById(performanceId)
+                .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
+
+        Mission mission = performance.getMission();
+
+        // 부모 권한 검증
+        if (!mission.getParent().getId().equals(parentId)) {
+            throw new MissionException(MissionErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        // 대기 상태인 미션만 승인 가능
+        if (performance.getStatus() != MissionStatus.PENDING) {
+            throw new IllegalStateException("대기 상태인 미션만 승인할 수 있습니다.");
+        }
+
+        performance.updateStatusAndReason(
+                MissionStatus.ACCEPTED,
+                "부모님이 미션을 승인했습니다."
+        );
+
+        // 해당 미션의 설정 정보 조회
+        MissionSetting setting = missionSettingRepository.findByMissionId(mission.getId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
+
+        int rewardTime = setting.getReward();
+
+        // 현재 날짜 기준 년월 조회
+        String currentYearMonth = YearMonth.now().toString();
+
+        // 자녀의 이번 달 시간 정책 조회
+        TimePolicy timePolicy = timePolicyRepository
+                .findByChildIdAndYearMonth(
+                        performance.getChild().getId(),
+                        currentYearMonth
+                )
+                .orElseThrow(() ->
+                        new IllegalArgumentException("이번 달에 설정된 자녀의 시간 정책(TimePolicy)이 없습니다."));
+
+        // 보상 시간 지급
+        timePolicy.addReward(rewardTime);
+
+        timePolicyRepository.save(timePolicy);
+
+        performanceRepository.save(performance);
+    }
+
+    @Transactional
+    public void rejectMission(Long performanceId, Long parentId) {
+
+        MissionPerformance performance = performanceRepository.findById(performanceId)
+                .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
+
+        Mission mission = performance.getMission();
+
+        // 부모 권한 검증
+        if (!mission.getParent().getId().equals(parentId)) {
+            throw new MissionException(MissionErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        // 대기 상태인 미션만 거절 가능
+        if (performance.getStatus() != MissionStatus.PENDING) {
+            throw new IllegalStateException("대기 상태인 미션만 거절할 수 있습니다.");
+        }
+
+        performance.updateStatusAndReason(
+                MissionStatus.REJECTED,
+                "부모님이 미션을 거절했습니다."
+        );
+
+        performanceRepository.save(performance);
+    }
+
 }


### PR DESCRIPTION
## 설명
현재 AI 자동 확인 방식을 확장하여 부모 확인 (PENDING 후 부모가 확인 처리) 방식과 자녀 확인 (자녀가 제출 시 자동 ACCEPT) 로직 구현

## 주요 변경 사항
- [x] 부모 확인 로직 구현
- [x] 자녀 확인 로직 구현
- [x] CODE 처리 부분에서 , 오류 수정

## 관련 이슈
- Closes https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/36
- Relates to https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/36