### PR TITLE
Feat: 알림 조회 및 알림 삭제 기능 구현

### DIFF
--- a/src/main/java/me/sogom/bridge/domain/member/code/MemberErrorCode.java
+++ b/src/main/java/me/sogom/bridge/domain/member/code/MemberErrorCode.java
@@ -18,7 +18,7 @@ public enum MemberErrorCode implements BaseErrorCode {
     CHILDREN_ALREADY_REGISTERED(HttpStatus.CONFLICT, "MEMBER409_CHILDREN", "이미 다른 부모와 연결된 자녀입니다."),
     PASSWORD_SAME_AS_OLD(HttpStatus.CONFLICT, "MEMBER409_PASSWORD_SAME", "새 비밀번호가 기존 비밀번호와 동일합니다."),
     PASSWORD_CHANGE_TOO_SOON(HttpStatus.TOO_MANY_REQUESTS, "MEMBER429_PASSWORD", "비밀번호는 24시간 내에 최대 1회만 변경할 수 있습니다."),
-    MEMBER_INACTIVE(HttpStatus.FORBIDDEN, "MEMBER403_INACTIVE", "비활성화된 계정입니다.");
+    MEMBER_INACTIVE(HttpStatus.FORBIDDEN, "MEMBER403_INACTIVE", "비활성화된 계정입니다."),
     CHILDREN_PARENT_MISMATCH(HttpStatus.UNAUTHORIZED, "MEMBER401_CHILDREN", "자녀와 부모의 연결이 올바르지 않습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/me/sogom/bridge/domain/member/code/MemberSuccessCode.java
+++ b/src/main/java/me/sogom/bridge/domain/member/code/MemberSuccessCode.java
@@ -18,7 +18,7 @@ public enum MemberSuccessCode implements BaseSuccessCode {
     CHILDREN_REGISTER_SUCCESS(HttpStatus.CREATED, "MEMBER201_CHILDREN_REGISTER", "자녀 등록에 성공했습니다."),
     CHILDREN_LIST_SUCCESS(HttpStatus.OK, "MEMBER200_CHILDREN_LIST", "자녀 목록 조회에 성공했습니다."),
     PASSWORD_CHANGE_SUCCESS(HttpStatus.OK, "MEMBER200_PASSWORD_CHANGE", "비밀번호 변경에 성공했습니다."),
-    MEMBER_WITHDRAW_SUCCESS(HttpStatus.OK, "MEMBER200_WITHDRAW", "회원 탈퇴에 성공했습니다.");
+    MEMBER_WITHDRAW_SUCCESS(HttpStatus.OK, "MEMBER200_WITHDRAW", "회원 탈퇴에 성공했습니다."),
     TIME_POLICY_SET_SUCCESS(HttpStatus.CREATED, "MEMBER201_TIME_POLICY_SET", "자녀 총시간 설정에 성공했습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
@@ -86,4 +86,37 @@ public class MissionController {
         MissionPerformanceResDTO.MissionPerformanceResponse response = performanceService.getMissionPerformance(missionId, parentId);
         return ApiResponse.onSuccess(MissionSuccessCode.MISSION_PERFORMANCE_RETRIEVE_SUCCESS, response);
     }
+
+    // 부모의 미션 승인 API
+    @PatchMapping("/performances/{performanceId}/approve")
+    public ApiResponse<String> approveMission(
+            @PathVariable Long performanceId,
+            @AuthenticationPrincipal AuthMember authMember) {
+
+        Long parentId = authMember.asParent().getId();
+
+        performanceService.approveMission(performanceId, parentId);
+
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                "미션 승인 완료"
+        );
+    }
+
+    // 부모의 미션 거절 API
+    @PatchMapping("/performances/{performanceId}/reject")
+    public ApiResponse<String> rejectMission(
+            @PathVariable Long performanceId,
+            @AuthenticationPrincipal AuthMember authMember) {
+
+        Long parentId = authMember.asParent().getId();
+
+        performanceService.rejectMission(performanceId, parentId);
+
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                "미션 거절 완료"
+        );
+    }
+
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
@@ -64,6 +64,62 @@ public class MissionPerformanceService {
                 .build();
         performanceRepository.save(performance);
 
+        // 미션 설정 정보 조회
+        MissionSetting setting = missionSettingRepository.findByMissionId(missionId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
+
+        // 미션 인증 방식 조회
+        VerificationType verificationType = setting.getVerificationType();
+
+        // 부모 확인 방식인 경우 부모 승인 대기 상태로 유지
+        if (verificationType == VerificationType.PARENT) {
+
+            performance.updateStatusAndReason(
+                    MissionStatus.PENDING,
+                    "부모님 확인 대기중입니다."
+            );
+
+            performanceRepository.save(performance);
+
+            return new AiVerificationResponse(
+                    false,
+                    "부모님 확인 대기중입니다."
+            );
+        }
+
+        // 자녀 확인 방식인 경우 즉시 승인 처리
+        if (verificationType == VerificationType.CHILD) {
+
+            performance.updateStatusAndReason(
+                    MissionStatus.ACCEPTED,
+                    "자녀 확인 방식으로 승인되었습니다."
+            );
+
+            // 해당 미션에 걸려있는 보상 시간 조회
+            int rewardTime = setting.getReward();
+
+            // 현재 날짜 기준 년월 조회
+            String currentYearMonth = YearMonth.now().toString();
+
+            // 자녀의 이번 달 시간 정책 조회
+            TimePolicy timePolicy = timePolicyRepository
+                    .findByChildIdAndYearMonth(childId, currentYearMonth)
+                    .orElseThrow(() ->
+                            new IllegalArgumentException("이번 달에 설정된 자녀의 시간 정책(TimePolicy)이 없습니다."));
+
+            // 보상 시간 지급
+            timePolicy.addReward(rewardTime);
+
+            timePolicyRepository.save(timePolicy);
+
+            performanceRepository.save(performance);
+
+            return new AiVerificationResponse(
+                    true,
+                    "미션 완료로 보상 시간이 지급되었습니다."
+            );
+        }
+
         // try-catch 블록 내부와 외부 모두에서 사용하기 위해 변수를 미리 선언합니다.
         AiVerificationResponse aiResponse;
 
@@ -80,8 +136,7 @@ public class MissionPerformanceService {
             // 미션 판독 결과가 성공(ACCEPTED)일 때만 실시간 보상 시간 정산 진행
             if (finalStatus == MissionStatus.ACCEPTED) {
                 // 해당 미션에 걸려있는 보상 시간(reward) 가져오기
-                MissionSetting setting = missionSettingRepository.findByMissionId(missionId)
-                        .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
+
                 int rewardTime = setting.getReward();
 
                 // 현재 날짜 기준 년월 구하기 (예: "2026-05")
@@ -128,4 +183,80 @@ public class MissionPerformanceService {
 
         return MissionPerformanceResDTO.MissionPerformanceResponse.of(performance);
     }
+
+    @Transactional
+    public void approveMission(Long performanceId, Long parentId) {
+
+        MissionPerformance performance = performanceRepository.findById(performanceId)
+                .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
+
+        Mission mission = performance.getMission();
+
+        // 부모 권한 검증
+        if (!mission.getParent().getId().equals(parentId)) {
+            throw new MissionException(MissionErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        // 대기 상태인 미션만 승인 가능
+        if (performance.getStatus() != MissionStatus.PENDING) {
+            throw new IllegalStateException("대기 상태인 미션만 승인할 수 있습니다.");
+        }
+
+        performance.updateStatusAndReason(
+                MissionStatus.ACCEPTED,
+                "부모님이 미션을 승인했습니다."
+        );
+
+        // 해당 미션의 설정 정보 조회
+        MissionSetting setting = missionSettingRepository.findByMissionId(mission.getId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
+
+        int rewardTime = setting.getReward();
+
+        // 현재 날짜 기준 년월 조회
+        String currentYearMonth = YearMonth.now().toString();
+
+        // 자녀의 이번 달 시간 정책 조회
+        TimePolicy timePolicy = timePolicyRepository
+                .findByChildIdAndYearMonth(
+                        performance.getChild().getId(),
+                        currentYearMonth
+                )
+                .orElseThrow(() ->
+                        new IllegalArgumentException("이번 달에 설정된 자녀의 시간 정책(TimePolicy)이 없습니다."));
+
+        // 보상 시간 지급
+        timePolicy.addReward(rewardTime);
+
+        timePolicyRepository.save(timePolicy);
+
+        performanceRepository.save(performance);
+    }
+
+    @Transactional
+    public void rejectMission(Long performanceId, Long parentId) {
+
+        MissionPerformance performance = performanceRepository.findById(performanceId)
+                .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
+
+        Mission mission = performance.getMission();
+
+        // 부모 권한 검증
+        if (!mission.getParent().getId().equals(parentId)) {
+            throw new MissionException(MissionErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        // 대기 상태인 미션만 거절 가능
+        if (performance.getStatus() != MissionStatus.PENDING) {
+            throw new IllegalStateException("대기 상태인 미션만 거절할 수 있습니다.");
+        }
+
+        performance.updateStatusAndReason(
+                MissionStatus.REJECTED,
+                "부모님이 미션을 거절했습니다."
+        );
+
+        performanceRepository.save(performance);
+    }
+
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
@@ -11,8 +11,11 @@ import me.sogom.bridge.domain.mission.exception.MissionException;
 import me.sogom.bridge.domain.mission.repository.MissionPerformanceRepository;
 import me.sogom.bridge.domain.mission.repository.MissionRepository;
 import me.sogom.bridge.domain.mission.repository.MissionSettingRepository;
+import me.sogom.bridge.domain.notification.entity.NotificationType;
+import me.sogom.bridge.domain.notification.service.NotificationService;
 import me.sogom.bridge.domain.policy.entity.TimePolicy;
 import me.sogom.bridge.domain.policy.repository.TimePolicyRepository;
+import me.sogom.bridge.global.security.entity.MemberRole;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -30,6 +33,9 @@ public class MissionPerformanceService {
     private final MissionVerificationAiService aiService;
     private final MissionSettingRepository missionSettingRepository;
     private final TimePolicyRepository timePolicyRepository;
+
+    // 알림 서비스
+    private final NotificationService notificationService;
 
     @Transactional // 데이터를 DB에 반영하기 위해 반드시 필요
     public AiVerificationResponse verifyAndSaveMission(Long missionId, Long childId, MultipartFile image, String prompt, MissionCategory category) throws IOException {
@@ -51,7 +57,6 @@ public class MissionPerformanceService {
                     // 이미 부모나 AI가 승인(ACCEPTED)한 미션이라면 더 이상 진행하지 못하게 차단!
                     if (lastPerformance.getStatus() == MissionStatus.ACCEPTED) {
                         throw new MissionException(MissionErrorCode.MISSION_ALREADY_COMPLETED);
-                        // ➡️ 익셉션 핸들러를 통해 포스트맨에 "이미 완료된 미션입니다" (400) 에러가 예쁘게 나감
                     }
                 });
 
@@ -80,6 +85,15 @@ public class MissionPerformanceService {
             );
 
             performanceRepository.save(performance);
+
+            // 부모에게 미션 확인 요청 알림 전송
+            notificationService.createNotification(
+                    mission.getParent().getId(),
+                    MemberRole.PARENT,
+                    "미션 확인 요청",
+                    child.getName() + "님이 미션 확인을 요청했습니다.",
+                    NotificationType.GENERAL
+            );
 
             return new AiVerificationResponse(
                     false,
@@ -114,13 +128,22 @@ public class MissionPerformanceService {
 
             performanceRepository.save(performance);
 
+            // 부모에게 자녀 미션 완료 알림 전송
+            notificationService.createNotification(
+                    mission.getParent().getId(),
+                    MemberRole.PARENT,
+                    "미션 완료",
+                    child.getName() + "님이 미션을 완료했습니다.",
+                    NotificationType.GENERAL
+            );
+
             return new AiVerificationResponse(
                     true,
                     "미션 완료로 보상 시간이 지급되었습니다."
             );
         }
 
-        // try-catch 블록 내부와 외부 모두에서 사용하기 위해 변수를 미리 선언합니다.
+        // AI 응답 변수 선언
         AiVerificationResponse aiResponse;
 
         try {
@@ -151,6 +174,15 @@ public class MissionPerformanceService {
 
                 // @Transactional 환경이므로 자동 반영되지만 가독성을 위해 호출 유지
                 timePolicyRepository.save(timePolicy);
+
+                // 부모에게 AI 인증 완료 알림 전송
+                notificationService.createNotification(
+                        mission.getParent().getId(),
+                        MemberRole.PARENT,
+                        "AI 미션 인증 완료",
+                        child.getName() + "님의 미션이 AI 인증되었습니다.",
+                        NotificationType.GENERAL
+                );
             }
 
         } catch (Exception e) {
@@ -174,6 +206,7 @@ public class MissionPerformanceService {
         Mission mission = missionRepository.findById(missionId)
                 .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
 
+        // 부모 권한 검증
         if (!mission.getParent().getId().equals(parentId)) {
             throw new MissionException(MissionErrorCode.UNAUTHORIZED_ACCESS);
         }
@@ -231,6 +264,15 @@ public class MissionPerformanceService {
         timePolicyRepository.save(timePolicy);
 
         performanceRepository.save(performance);
+
+        // 자녀에게 승인 알림 전송
+        notificationService.createNotification(
+                performance.getChild().getId(),
+                MemberRole.CHILDREN,
+                "미션 승인 완료",
+                "부모님이 미션을 승인했습니다.",
+                NotificationType.MISSION_APPROVED
+        );
     }
 
     @Transactional
@@ -257,6 +299,14 @@ public class MissionPerformanceService {
         );
 
         performanceRepository.save(performance);
-    }
 
+        // 자녀에게 거절 알림 전송
+        notificationService.createNotification(
+                performance.getChild().getId(),
+                MemberRole.CHILDREN,
+                "미션 거절",
+                "부모님이 미션을 거절했습니다.",
+                NotificationType.MISSION_REJECTED
+        );
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionService.java
@@ -15,6 +15,9 @@ import me.sogom.bridge.domain.mission.exception.MissionErrorCode;
 import me.sogom.bridge.domain.mission.exception.MissionException;
 import me.sogom.bridge.domain.mission.repository.MissionRepository;
 import me.sogom.bridge.domain.mission.repository.MissionSettingRepository;
+import me.sogom.bridge.domain.notification.entity.NotificationType;
+import me.sogom.bridge.domain.notification.service.NotificationService;
+import me.sogom.bridge.global.security.entity.MemberRole;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +32,8 @@ public class MissionService {
     private final MissionSettingRepository missionSettingRepository;
     private final ParentRepository parentRepository;
     private final ChildrenRepository childrenRepository;
+    // 알림 서비스
+    private final NotificationService notificationService;
 
     @Transactional
     public MissionResDTO.MissionResponse createMission(Long parentId, MissionReqDTO.CreateMissionRequest request) {
@@ -61,6 +66,15 @@ public class MissionService {
                 .lastResetAt(LocalDateTime.now())
                 .build();
         missionSettingRepository.save(setting);
+
+        // 자녀에게 새 미션 생성 알림 전송
+        notificationService.createNotification(
+                child.getId(),
+                MemberRole.CHILDREN,
+                "새 미션이 생성되었습니다.",
+                mission.getTitle(),
+                NotificationType.MISSION_CREATED
+        );
 
         return MissionResDTO.MissionResponse.of(mission, setting);
     }

--- a/src/main/java/me/sogom/bridge/domain/notification/controller/NotificationController.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/controller/NotificationController.java
@@ -1,0 +1,92 @@
+package me.sogom.bridge.domain.notification.controller;
+
+import lombok.RequiredArgsConstructor;
+import me.sogom.bridge.domain.notification.dto.req.NotificationReqDTO;
+import me.sogom.bridge.domain.notification.dto.res.NotificationResDTO;
+import me.sogom.bridge.domain.notification.service.NotificationService;
+import me.sogom.bridge.global.apiPayload.ApiResponse;
+import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
+import me.sogom.bridge.global.security.entity.AuthMember;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    // 알림 목록 조회 API
+    @GetMapping
+    public ApiResponse<List<NotificationResDTO.NotificationResponse>> getNotifications(
+            @AuthenticationPrincipal AuthMember authMember
+    ) {
+
+        // 현재 로그인한 회원 ID 조회
+        Long memberId = authMember.getMember().getId();
+
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                notificationService.getNotifications(memberId)
+        );
+    }
+
+    // 알림 읽음 처리 API
+    @PatchMapping("/{notificationId}/read")
+    public ApiResponse<String> readNotification(
+            @PathVariable Long notificationId,
+            @AuthenticationPrincipal AuthMember authMember
+    ) {
+
+        // 현재 로그인한 회원 ID 조회
+        Long memberId = authMember.getMember().getId();
+
+        notificationService.readNotification(notificationId, memberId);
+
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                "알림 읽음 처리 완료"
+        );
+    }
+
+    // 알림 삭제 API
+    @DeleteMapping("/{notificationId}")
+    public ApiResponse<String> deleteNotification(
+            @PathVariable Long notificationId,
+            @AuthenticationPrincipal AuthMember authMember
+    ) {
+
+        // 현재 로그인한 회원 ID 조회
+        Long memberId = authMember.getMember().getId();
+
+        notificationService.deleteNotification(notificationId, memberId);
+
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                "알림 삭제 완료"
+        );
+    }
+
+    // 알림 생성 API
+    @PostMapping
+    public ApiResponse<String> createNotification(
+            @RequestBody NotificationReqDTO.CreateNotificationRequest request
+    ) {
+
+        notificationService.createNotification(
+                request.memberId(),
+                request.title(),
+                request.content(),
+                request.notificationType()
+        );
+
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                "알림 생성 완료"
+        );
+    }
+
+}

--- a/src/main/java/me/sogom/bridge/domain/notification/controller/NotificationController.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/controller/NotificationController.java
@@ -7,6 +7,7 @@ import me.sogom.bridge.domain.notification.service.NotificationService;
 import me.sogom.bridge.global.apiPayload.ApiResponse;
 import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
 import me.sogom.bridge.global.security.entity.AuthMember;
+import me.sogom.bridge.global.security.entity.MemberRole;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,6 +20,26 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
+    // 알림 생성 API
+    @PostMapping
+    public ApiResponse<String> createNotification(
+            @RequestBody NotificationReqDTO.CreateNotificationRequest request
+    ) {
+
+        notificationService.createNotification(
+                request.memberId(),
+                request.memberRole(),
+                request.title(),
+                request.content(),
+                request.notificationType()
+        );
+
+        return ApiResponse.onSuccess(
+                GeneralSuccessCode.OK,
+                "알림 생성 완료"
+        );
+    }
+
     // 알림 목록 조회 API
     @GetMapping
     public ApiResponse<List<NotificationResDTO.NotificationResponse>> getNotifications(
@@ -28,9 +49,12 @@ public class NotificationController {
         // 현재 로그인한 회원 ID 조회
         Long memberId = authMember.getMember().getId();
 
+        // 현재 로그인한 회원 역할 조회
+        MemberRole memberRole = authMember.getRole();
+
         return ApiResponse.onSuccess(
                 GeneralSuccessCode.OK,
-                notificationService.getNotifications(memberId)
+                notificationService.getNotifications(memberId, memberRole)
         );
     }
 
@@ -44,7 +68,14 @@ public class NotificationController {
         // 현재 로그인한 회원 ID 조회
         Long memberId = authMember.getMember().getId();
 
-        notificationService.readNotification(notificationId, memberId);
+        // 현재 로그인한 회원 역할 조회
+        MemberRole memberRole = authMember.getRole();
+
+        notificationService.readNotification(
+                notificationId,
+                memberId,
+                memberRole
+        );
 
         return ApiResponse.onSuccess(
                 GeneralSuccessCode.OK,
@@ -62,31 +93,18 @@ public class NotificationController {
         // 현재 로그인한 회원 ID 조회
         Long memberId = authMember.getMember().getId();
 
-        notificationService.deleteNotification(notificationId, memberId);
+        // 현재 로그인한 회원 역할 조회
+        MemberRole memberRole = authMember.getRole();
+
+        notificationService.deleteNotification(
+                notificationId,
+                memberId,
+                memberRole
+        );
 
         return ApiResponse.onSuccess(
                 GeneralSuccessCode.OK,
                 "알림 삭제 완료"
         );
     }
-
-    // 알림 생성 API
-    @PostMapping
-    public ApiResponse<String> createNotification(
-            @RequestBody NotificationReqDTO.CreateNotificationRequest request
-    ) {
-
-        notificationService.createNotification(
-                request.memberId(),
-                request.title(),
-                request.content(),
-                request.notificationType()
-        );
-
-        return ApiResponse.onSuccess(
-                GeneralSuccessCode.OK,
-                "알림 생성 완료"
-        );
-    }
-
 }

--- a/src/main/java/me/sogom/bridge/domain/notification/dto/req/NotificationReqDTO.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/dto/req/NotificationReqDTO.java
@@ -3,6 +3,7 @@ package me.sogom.bridge.domain.notification.dto.req;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import me.sogom.bridge.domain.notification.entity.NotificationType;
+import me.sogom.bridge.global.security.entity.MemberRole;
 
 public class NotificationReqDTO {
 
@@ -10,6 +11,9 @@ public class NotificationReqDTO {
 
             @NotNull
             Long memberId,
+
+            @NotNull
+            MemberRole memberRole,
 
             @NotBlank
             String title,

--- a/src/main/java/me/sogom/bridge/domain/notification/dto/req/NotificationReqDTO.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/dto/req/NotificationReqDTO.java
@@ -1,0 +1,25 @@
+package me.sogom.bridge.domain.notification.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import me.sogom.bridge.domain.notification.entity.NotificationType;
+
+public class NotificationReqDTO {
+
+    public record CreateNotificationRequest(
+
+            @NotNull
+            Long memberId,
+
+            @NotBlank
+            String title,
+
+            @NotBlank
+            String content,
+
+            @NotNull
+            NotificationType notificationType
+
+    ) {
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/notification/dto/res/NotificationResDTO.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/dto/res/NotificationResDTO.java
@@ -1,0 +1,41 @@
+package me.sogom.bridge.domain.notification.dto.res;
+
+import lombok.Builder;
+import me.sogom.bridge.domain.notification.entity.Notification;
+import me.sogom.bridge.domain.notification.entity.NotificationType;
+
+import java.time.LocalDateTime;
+
+public class NotificationResDTO {
+
+    @Builder
+    public record NotificationResponse(
+
+            Long notificationId,
+
+            String title,
+
+            String content,
+
+            Boolean isRead,
+
+            NotificationType notificationType,
+
+            LocalDateTime createdAt
+
+    ) {
+
+        // 엔티티를 응답 DTO로 변환
+        public static NotificationResponse of(Notification notification) {
+
+            return NotificationResponse.builder()
+                    .notificationId(notification.getId())
+                    .title(notification.getTitle())
+                    .content(notification.getContent())
+                    .isRead(notification.getIsRead())
+                    .notificationType(notification.getNotificationType())
+                    .createdAt(notification.getCreatedAt())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/notification/entity/Notification.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/entity/Notification.java
@@ -1,0 +1,60 @@
+package me.sogom.bridge.domain.notification.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.sogom.bridge.domain.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "notification")
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 알림 수신 회원 ID
+    @Column(nullable = false)
+    private Long memberId;
+
+    // 알림 제목
+    @Column(nullable = false)
+    private String title;
+
+    // 알림 내용
+    @Column(nullable = false)
+    private String content;
+
+    // 알림 읽음 여부
+    @Column(nullable = false)
+    private Boolean isRead;
+
+    // 알림 타입
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType notificationType;
+
+    @Builder
+    public Notification(
+            Long memberId,
+            String title,
+            String content,
+            Boolean isRead,
+            NotificationType notificationType
+    ) {
+        this.memberId = memberId;
+        this.title = title;
+        this.content = content;
+        this.isRead = isRead;
+        this.notificationType = notificationType;
+    }
+
+    // 알림 읽음 처리
+    public void read() {
+        this.isRead = true;
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/notification/entity/Notification.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/entity/Notification.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import me.sogom.bridge.domain.common.BaseEntity;
+import me.sogom.bridge.global.security.entity.MemberRole;
 
 @Entity
 @Getter
@@ -20,6 +21,11 @@ public class Notification extends BaseEntity {
     // 알림 수신 회원 ID
     @Column(nullable = false)
     private Long memberId;
+
+    // 알림 수신 회원 역할
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberRole memberRole;
 
     // 알림 제목
     @Column(nullable = false)
@@ -41,12 +47,14 @@ public class Notification extends BaseEntity {
     @Builder
     public Notification(
             Long memberId,
+            MemberRole memberRole,
             String title,
             String content,
             Boolean isRead,
             NotificationType notificationType
     ) {
         this.memberId = memberId;
+        this.memberRole = memberRole;
         this.title = title;
         this.content = content;
         this.isRead = isRead;

--- a/src/main/java/me/sogom/bridge/domain/notification/entity/NotificationType.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/entity/NotificationType.java
@@ -1,0 +1,9 @@
+package me.sogom.bridge.domain.notification.entity;
+
+public enum NotificationType {
+
+    MISSION_CREATED,
+    MISSION_APPROVED,
+    MISSION_REJECTED,
+    GENERAL
+}

--- a/src/main/java/me/sogom/bridge/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,12 @@
+package me.sogom.bridge.domain.notification.repository;
+
+import me.sogom.bridge.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    // 회원의 알림 목록 조회
+    List<Notification> findAllByMemberIdOrderByCreatedAtDesc(Long memberId);
+}

--- a/src/main/java/me/sogom/bridge/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/repository/NotificationRepository.java
@@ -1,6 +1,7 @@
 package me.sogom.bridge.domain.notification.repository;
 
 import me.sogom.bridge.domain.notification.entity.Notification;
+import me.sogom.bridge.global.security.entity.MemberRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,5 +9,8 @@ import java.util.List;
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     // 회원의 알림 목록 조회
-    List<Notification> findAllByMemberIdOrderByCreatedAtDesc(Long memberId);
+    List<Notification> findAllByMemberIdAndMemberRoleOrderByCreatedAtDesc(
+            Long memberId,
+            MemberRole memberRole
+    );
 }

--- a/src/main/java/me/sogom/bridge/domain/notification/service/NotificationService.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/service/NotificationService.java
@@ -1,0 +1,78 @@
+package me.sogom.bridge.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import me.sogom.bridge.domain.notification.dto.res.NotificationResDTO;
+import me.sogom.bridge.domain.notification.entity.Notification;
+import me.sogom.bridge.domain.notification.entity.NotificationType;
+import me.sogom.bridge.domain.notification.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    // 알림 생성
+    @Transactional
+    public void createNotification(
+            Long memberId,
+            String title,
+            String content,
+            NotificationType notificationType
+    ) {
+
+        Notification notification = Notification.builder()
+                .memberId(memberId)
+                .title(title)
+                .content(content)
+                .isRead(false)
+                .notificationType(notificationType)
+                .build();
+
+        notificationRepository.save(notification);
+    }
+
+    // 회원의 알림 목록 조회
+    @Transactional(readOnly = true)
+    public List<NotificationResDTO.NotificationResponse> getNotifications(Long memberId) {
+
+        return notificationRepository.findAllByMemberIdOrderByCreatedAtDesc(memberId)
+                .stream()
+                .map(NotificationResDTO.NotificationResponse::of)
+                .toList();
+    }
+
+    // 알림 읽음 처리
+    @Transactional
+    public void readNotification(Long notificationId, Long memberId) {
+
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new IllegalArgumentException("알림을 찾을 수 없습니다."));
+
+        // 본인의 알림만 읽음 처리 가능
+        if (!notification.getMemberId().equals(memberId)) {
+            throw new IllegalArgumentException("본인의 알림만 읽을 수 있습니다.");
+        }
+
+        notification.read();
+    }
+
+    // 알림 삭제
+    @Transactional
+    public void deleteNotification(Long notificationId, Long memberId) {
+
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new IllegalArgumentException("알림을 찾을 수 없습니다."));
+
+        // 본인의 알림만 삭제 가능
+        if (!notification.getMemberId().equals(memberId)) {
+            throw new IllegalArgumentException("본인의 알림만 삭제할 수 있습니다.");
+        }
+
+        notificationRepository.delete(notification);
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/notification/service/NotificationService.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/service/NotificationService.java
@@ -5,6 +5,7 @@ import me.sogom.bridge.domain.notification.dto.res.NotificationResDTO;
 import me.sogom.bridge.domain.notification.entity.Notification;
 import me.sogom.bridge.domain.notification.entity.NotificationType;
 import me.sogom.bridge.domain.notification.repository.NotificationRepository;
+import me.sogom.bridge.global.security.entity.MemberRole;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,7 @@ public class NotificationService {
     @Transactional
     public void createNotification(
             Long memberId,
+            MemberRole memberRole,
             String title,
             String content,
             NotificationType notificationType
@@ -27,6 +29,7 @@ public class NotificationService {
 
         Notification notification = Notification.builder()
                 .memberId(memberId)
+                .memberRole(memberRole)
                 .title(title)
                 .content(content)
                 .isRead(false)
@@ -38,9 +41,16 @@ public class NotificationService {
 
     // 회원의 알림 목록 조회
     @Transactional(readOnly = true)
-    public List<NotificationResDTO.NotificationResponse> getNotifications(Long memberId) {
+    public List<NotificationResDTO.NotificationResponse> getNotifications(
+            Long memberId,
+            MemberRole memberRole
+    ) {
 
-        return notificationRepository.findAllByMemberIdOrderByCreatedAtDesc(memberId)
+        return notificationRepository
+                .findAllByMemberIdAndMemberRoleOrderByCreatedAtDesc(
+                        memberId,
+                        memberRole
+                )
                 .stream()
                 .map(NotificationResDTO.NotificationResponse::of)
                 .toList();
@@ -48,13 +58,19 @@ public class NotificationService {
 
     // 알림 읽음 처리
     @Transactional
-    public void readNotification(Long notificationId, Long memberId) {
+    public void readNotification(
+            Long notificationId,
+            Long memberId,
+            MemberRole memberRole
+    ) {
 
         Notification notification = notificationRepository.findById(notificationId)
                 .orElseThrow(() -> new IllegalArgumentException("알림을 찾을 수 없습니다."));
 
         // 본인의 알림만 읽음 처리 가능
-        if (!notification.getMemberId().equals(memberId)) {
+        if (!notification.getMemberId().equals(memberId)
+                || !notification.getMemberRole().equals(memberRole)) {
+
             throw new IllegalArgumentException("본인의 알림만 읽을 수 있습니다.");
         }
 
@@ -63,13 +79,19 @@ public class NotificationService {
 
     // 알림 삭제
     @Transactional
-    public void deleteNotification(Long notificationId, Long memberId) {
+    public void deleteNotification(
+            Long notificationId,
+            Long memberId,
+            MemberRole memberRole
+    ) {
 
         Notification notification = notificationRepository.findById(notificationId)
                 .orElseThrow(() -> new IllegalArgumentException("알림을 찾을 수 없습니다."));
 
         // 본인의 알림만 삭제 가능
-        if (!notification.getMemberId().equals(memberId)) {
+        if (!notification.getMemberId().equals(memberId)
+                || !notification.getMemberRole().equals(memberRole)) {
+
             throw new IllegalArgumentException("본인의 알림만 삭제할 수 있습니다.");
         }
 


### PR DESCRIPTION
## 설명
알림 CRUD 제작

## 주요 변경사항
- [x] Noti Entity 생성
- [x] 알림창 내역 조회 로직
- [x] 알림창 내역 삭제 로직
- [x] 알림 생성 로직
- [x] 권한 예외처리
- [x] 미션 기능 별 알림 서비스 연동
### 자녀 -> 부모
미션 확인 요청 알림
미션 완료 알림
AI 미션 인증 완료 알림
(GENERAL 처리)
### 부모 -> 자녀
미션 승인 완료 알림 (MISSION_APPROVED)
미션 승인 거절 알림 (MISSION_REJECTED)
미션 생성 알림 (MISSION_CREATED) 


## 관련 이슈
- Closes https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/35
- Relates to https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/35