### PR TITLE
Feat: FCM 실시간 푸시 알림 인프라 및 공통 발송 서비스 구축

### DIFF
--- a/src/main/java/me/sogom/bridge/domain/fcm/controller/FcmController.java
+++ b/src/main/java/me/sogom/bridge/domain/fcm/controller/FcmController.java
@@ -1,0 +1,72 @@
+package me.sogom.bridge.domain.fcm.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import me.sogom.bridge.domain.fcm.dto.message.FcmMessageDTO;
+import me.sogom.bridge.domain.fcm.dto.req.FcmReqDTO;
+import me.sogom.bridge.domain.fcm.service.FcmService;
+import me.sogom.bridge.domain.member.code.MemberSuccessCode;
+import me.sogom.bridge.global.apiPayload.ApiResponse;
+import me.sogom.bridge.global.security.entity.AuthMember;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/fcm")
+@Tag(name = "FCM API")
+public class FcmController {
+
+    private final FcmService fcmService;
+
+    @Operation(
+            summary = "FCM 토큰 저장",
+            description = "사용자의 FCM 토큰 저장 및 갱신 API"
+    )
+    @PostMapping("/token")
+    public ApiResponse<String> saveFcmToken(
+            @AuthenticationPrincipal AuthMember authMember,
+            @RequestBody @Valid FcmReqDTO.SaveFcmTokenRequest request
+    ) {
+
+        fcmService.saveFcmToken(
+                authMember,
+                request.fcmToken()
+        );
+
+        return ApiResponse.onSuccess(
+                MemberSuccessCode.FCM_TOKEN_SAVE_SUCCESS,
+                "FCM 토큰 저장 완료"
+        );
+    }
+
+    @Operation(
+            summary = "FCM 테스트 푸시",
+            description = "테스트용 푸시 알림 발송 API"
+    )
+    @PostMapping("/test")
+    public ApiResponse<String> testPush(
+            @AuthenticationPrincipal AuthMember authMember
+    ) {
+
+        FcmMessageDTO message = FcmMessageDTO.builder()
+                .title("테스트 알림")
+                .body("FCM 테스트 알림입니다.")
+                .type("TEST")
+                .targetId(0L)
+                .build();
+
+        fcmService.sendPush(
+                authMember.getMember().getId(),
+                authMember.getRole(),
+                message
+        );
+
+        return ApiResponse.onSuccess(
+                MemberSuccessCode.FCM_TOKEN_SAVE_SUCCESS,
+                "테스트 푸시 발송 완료"
+        );
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/fcm/dto/message/FcmMessageDTO.java
+++ b/src/main/java/me/sogom/bridge/domain/fcm/dto/message/FcmMessageDTO.java
@@ -1,0 +1,17 @@
+package me.sogom.bridge.domain.fcm.dto.message;
+
+import lombok.Builder;
+
+@Builder
+public record FcmMessageDTO(
+
+        String title,
+
+        String body,
+
+        String type,
+
+        Long targetId
+
+) {
+}

--- a/src/main/java/me/sogom/bridge/domain/fcm/dto/req/FcmReqDTO.java
+++ b/src/main/java/me/sogom/bridge/domain/fcm/dto/req/FcmReqDTO.java
@@ -1,0 +1,14 @@
+package me.sogom.bridge.domain.fcm.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class FcmReqDTO {
+
+    public record SaveFcmTokenRequest(
+
+            @NotBlank
+            String fcmToken
+
+    ) {
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/fcm/service/FcmService.java
+++ b/src/main/java/me/sogom/bridge/domain/fcm/service/FcmService.java
@@ -1,0 +1,28 @@
+package me.sogom.bridge.domain.fcm.service;
+
+import me.sogom.bridge.domain.fcm.dto.message.FcmMessageDTO;
+import me.sogom.bridge.global.security.entity.AuthMember;
+import me.sogom.bridge.global.security.entity.MemberRole;
+
+public interface FcmService {
+
+    // FCM 토큰 저장 및 갱신
+    void saveFcmToken(
+            AuthMember authMember,
+            String fcmToken
+    );
+
+    // 일반 푸시 알림 전송
+    void sendPush(
+            Long memberId,
+            MemberRole memberRole,
+            FcmMessageDTO message
+    );
+
+    // Silent Push 전송
+    void sendSilentPush(
+            Long memberId,
+            MemberRole memberRole,
+            String type
+    );
+}

--- a/src/main/java/me/sogom/bridge/domain/fcm/service/FirebaseFcmService.java
+++ b/src/main/java/me/sogom/bridge/domain/fcm/service/FirebaseFcmService.java
@@ -1,0 +1,45 @@
+package me.sogom.bridge.domain.fcm.service;
+
+import lombok.extern.slf4j.Slf4j;
+import me.sogom.bridge.domain.fcm.dto.message.FcmMessageDTO;
+import me.sogom.bridge.global.security.entity.AuthMember;
+import me.sogom.bridge.global.security.entity.MemberRole;
+
+@Slf4j
+//@Service  실제로 Firebase 연동 시 주석 처리 해제 및 MockFcmService의 @Service 해제
+public class FirebaseFcmService implements FcmService {
+
+    // 실제 Firebase 연동 예정 서비스
+    // Firebase service-account.json 연결 후 구현 예정
+
+    @Override
+    public void sendPush(
+            Long memberId,
+            MemberRole memberRole,
+            FcmMessageDTO message
+    ) {
+
+        log.info("Firebase 일반 푸시 전송 예정");
+    }
+
+    @Override
+    public void sendSilentPush(
+            Long memberId,
+            MemberRole memberRole,
+            String type
+    ) {
+
+        log.info("Firebase Silent Push 전송 예정");
+    }
+
+    // Firebase 토큰 저장 예정
+    @Override
+    public void saveFcmToken(
+            AuthMember authMember,
+            String fcmToken
+    ) {
+
+        log.info("Firebase FCM 토큰 저장 예정");
+    }
+
+}

--- a/src/main/java/me/sogom/bridge/domain/fcm/service/MockFcmService.java
+++ b/src/main/java/me/sogom/bridge/domain/fcm/service/MockFcmService.java
@@ -1,0 +1,124 @@
+package me.sogom.bridge.domain.fcm.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.sogom.bridge.domain.fcm.dto.message.FcmMessageDTO;
+import me.sogom.bridge.domain.member.entity.Children;
+import me.sogom.bridge.domain.member.entity.Parent;
+import me.sogom.bridge.domain.member.repository.ChildrenRepository;
+import me.sogom.bridge.domain.member.repository.ParentRepository;
+import me.sogom.bridge.global.security.entity.AuthMember;
+import me.sogom.bridge.global.security.entity.MemberRole;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@Primary
+@RequiredArgsConstructor
+public class MockFcmService implements FcmService {
+
+    private final ParentRepository parentRepository;
+    private final ChildrenRepository childrenRepository;
+
+    // 일반 푸시 알림 Mock 전송
+    @Override
+    public void sendPush(
+            Long memberId,
+            MemberRole memberRole,
+            FcmMessageDTO message
+    ) {
+
+        String fcmToken = getFcmToken(memberId, memberRole);
+
+        // 토큰이 없는 경우 전송하지 않음
+        if (fcmToken == null || fcmToken.isBlank()) {
+            return;
+        }
+
+        log.info("푸시 알림 전송");
+        log.info("FCM Token : {}", fcmToken);
+        log.info("Title : {}", message.title());
+        log.info("Body : {}", message.body());
+        log.info("Type : {}", message.type());
+        log.info("TargetId : {}", message.targetId());
+    }
+
+    // Silent Push Mock 전송
+    @Override
+    public void sendSilentPush(
+            Long memberId,
+            MemberRole memberRole,
+            String type
+    ) {
+
+        String fcmToken = getFcmToken(memberId, memberRole);
+
+        // 토큰이 없는 경우 전송하지 않음
+        if (fcmToken == null || fcmToken.isBlank()) {
+            return;
+        }
+
+        log.info("Silent Push 전송");
+        log.info("FCM Token : {}", fcmToken);
+        log.info("Type : {}", type);
+    }
+
+    // 회원 역할에 따라 FCM 토큰 조회
+    private String getFcmToken(
+            Long memberId,
+            MemberRole memberRole
+    ) {
+
+        // 부모 회원 조회
+        if (memberRole == MemberRole.PARENT) {
+
+            Parent parent = parentRepository.findById(memberId)
+                    .orElseThrow(() -> new IllegalArgumentException("부모 회원을 찾을 수 없습니다."));
+
+            return parent.getFcmToken();
+        }
+
+        // 자녀 회원 조회
+        if (memberRole == MemberRole.CHILDREN) {
+
+            Children children = childrenRepository.findById(memberId)
+                    .orElseThrow(() -> new IllegalArgumentException("자녀 회원을 찾을 수 없습니다."));
+
+            return children.getFcmToken();
+        }
+
+        return null;
+    }
+
+    // FCM 토큰 저장 및 갱신
+    @Override
+    public void saveFcmToken(
+            AuthMember authMember,
+            String fcmToken
+    ) {
+
+        // 부모 계정인 경우
+        if (authMember.getRole() == MemberRole.PARENT) {
+
+            Parent parent = authMember.asParent();
+
+            parent.updateFcmToken(fcmToken);
+
+            parentRepository.save(parent);
+
+            return;
+        }
+
+        // 자녀 계정인 경우
+        if (authMember.getRole() == MemberRole.CHILDREN) {
+
+            Children children = authMember.asChildren();
+
+            children.updateFcmToken(fcmToken);
+
+            childrenRepository.save(children);
+        }
+    }
+
+}

--- a/src/main/java/me/sogom/bridge/domain/member/code/MemberSuccessCode.java
+++ b/src/main/java/me/sogom/bridge/domain/member/code/MemberSuccessCode.java
@@ -19,7 +19,8 @@ public enum MemberSuccessCode implements BaseSuccessCode {
     CHILDREN_LIST_SUCCESS(HttpStatus.OK, "MEMBER200_CHILDREN_LIST", "자녀 목록 조회에 성공했습니다."),
     PASSWORD_CHANGE_SUCCESS(HttpStatus.OK, "MEMBER200_PASSWORD_CHANGE", "비밀번호 변경에 성공했습니다."),
     MEMBER_WITHDRAW_SUCCESS(HttpStatus.OK, "MEMBER200_WITHDRAW", "회원 탈퇴에 성공했습니다."),
-    TIME_POLICY_SET_SUCCESS(HttpStatus.CREATED, "MEMBER201_TIME_POLICY_SET", "자녀 총시간 설정에 성공했습니다.");
+    TIME_POLICY_SET_SUCCESS(HttpStatus.CREATED, "MEMBER201_TIME_POLICY_SET", "자녀 총시간 설정에 성공했습니다."),
+    FCM_TOKEN_SAVE_SUCCESS(HttpStatus.OK, "MEMBER200_FCM_TOKEN", "FCM 토큰 저장에 성공했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/me/sogom/bridge/domain/member/entity/Children.java
+++ b/src/main/java/me/sogom/bridge/domain/member/entity/Children.java
@@ -44,6 +44,10 @@ public class Children extends BaseEntity implements Member {
     @Column(length = 100)
     private String profileImageUrl;
 
+    // FCM 토큰 저장
+    @Column(length = 500)
+    private String fcmToken;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private Parent parent;
@@ -51,6 +55,11 @@ public class Children extends BaseEntity implements Member {
     public void changePassword(String newHash, LocalDateTime changedAt) {
         this.hash = newHash;
         this.passwordChangedAt = changedAt;
+    }
+
+    // FCM 토큰 저장 및 갱신
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
     }
 
     public void markDormant() {

--- a/src/main/java/me/sogom/bridge/domain/member/entity/Parent.java
+++ b/src/main/java/me/sogom/bridge/domain/member/entity/Parent.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -37,6 +38,10 @@ public class Parent extends BaseEntity implements Member {
     @Column
     private LocalDateTime passwordChangedAt;
 
+    // FCM 토큰 저장
+    @Column(length = 500)
+    private String fcmToken;
+
     @OneToMany(mappedBy = "parent", cascade = CascadeType.REMOVE, orphanRemoval = true)
     @Builder.Default
     private List<Children> children = new ArrayList<>();
@@ -44,6 +49,11 @@ public class Parent extends BaseEntity implements Member {
     public void changePassword(String newHash, LocalDateTime changedAt) {
         this.hash = newHash;
         this.passwordChangedAt = changedAt;
+    }
+
+    // FCM 토큰 저장 및 갱신
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
     }
 
     public void withdraw() {

--- a/src/main/java/me/sogom/bridge/domain/member/service/ParentService.java
+++ b/src/main/java/me/sogom/bridge/domain/member/service/ParentService.java
@@ -1,8 +1,9 @@
 package me.sogom.bridge.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
-import me.sogom.bridge.domain.member.code.MemberErrorCode;
+import me.sogom.bridge.domain.fcm.service.FcmService;
 import me.sogom.bridge.domain.member.MemberException;
+import me.sogom.bridge.domain.member.code.MemberErrorCode;
 import me.sogom.bridge.domain.member.dto.req.MemberReqDTO;
 import me.sogom.bridge.domain.member.dto.res.MemberResDTO;
 import me.sogom.bridge.domain.member.entity.Children;
@@ -13,6 +14,7 @@ import me.sogom.bridge.domain.member.repository.ParentRepository;
 import me.sogom.bridge.domain.policy.dto.PolicyReqDTO;
 import me.sogom.bridge.domain.policy.entity.TimePolicy;
 import me.sogom.bridge.domain.policy.repository.TimePolicyRepository;
+import me.sogom.bridge.global.security.entity.MemberRole;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +28,9 @@ public class ParentService {
     private final ParentRepository parentRepository;
     private final ChildrenRepository childrenRepository;
     private final TimePolicyRepository timePolicyRepository;
+
+    // FCM 서비스
+    private final FcmService fcmService;
 
     /**
      * 부모 - 자녀 등록
@@ -92,8 +97,11 @@ public class ParentService {
 
         timePolicyRepository.findByChildIdAndYearMonth(request.childId(), request.yearMonth())
                 .ifPresentOrElse(
+
+                        // 이미 존재하는 경우 기본 시간 수정
                         policy -> policy.updateBaseTime(request.baseTime()),
 
+                        // 존재하지 않는 경우 새 정책 생성
                         () -> {
                             TimePolicy newPolicy = TimePolicy.builder()
                                     .parent(parent)
@@ -106,6 +114,11 @@ public class ParentService {
                         }
                 );
 
+        // 자녀 앱 정책 갱신 Silent Push 전송
+        fcmService.sendSilentPush(
+                child.getId(),
+                MemberRole.CHILDREN,
+                "TIME_POLICY_UPDATED"
+        );
     }
 }
-

--- a/src/main/java/me/sogom/bridge/domain/notification/service/NotificationService.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/service/NotificationService.java
@@ -1,6 +1,9 @@
 package me.sogom.bridge.domain.notification.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.sogom.bridge.domain.fcm.dto.message.FcmMessageDTO;
+import me.sogom.bridge.domain.fcm.service.FcmService;
 import me.sogom.bridge.domain.notification.dto.res.NotificationResDTO;
 import me.sogom.bridge.domain.notification.entity.Notification;
 import me.sogom.bridge.domain.notification.entity.NotificationType;
@@ -11,11 +14,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+
+    // FCM 서비스
+    private final FcmService fcmService;
 
     // 알림 생성
     @Transactional
@@ -36,7 +43,30 @@ public class NotificationService {
                 .notificationType(notificationType)
                 .build();
 
+        // 알림 저장
         notificationRepository.save(notification);
+
+        // FCM 푸시 전송
+        try {
+
+            FcmMessageDTO message = FcmMessageDTO.builder()
+                    .title(title)
+                    .body(content)
+                    .type(notificationType.name())
+                    .targetId(notification.getId())
+                    .build();
+
+            fcmService.sendPush(
+                    memberId,
+                    memberRole,
+                    message
+            );
+
+        } catch (Exception e) {
+
+            // FCM 실패 시 Notification 저장은 유지
+            log.error("FCM 푸시 알림 전송 실패", e);
+        }
     }
 
     // 회원의 알림 목록 조회


### PR DESCRIPTION
## 설명

기존 Notification CRUD 기능에 Firebase Cloud Messaging 기반 푸시 알림 기능을 추가한다.
현재 구현된 Notification 저장 및 미션 이벤트 알림 기능과 연동하여 특정 이벤트 발생 시 실제 사용자 디바이스로 푸시 알림을 전송할 수 있도록 구현한다.
Flutter 앱에서 발급한 FCM 토큰을 서버에 저장하고, 미션 관련 이벤트 발생 시 Notification 저장과 함께 푸시 알림이 전송되도록 구성한다.

## 참고사항
아직 Firebase json이 없어서 실제 연동 부분 구축은 미완이나 Mock Push 기반 로그 테스트 완료했습니다. 
Firebase service-account json 전달 이후 실제 Firebase 연동 관련 미구현 사항은 추가 PR 예정입니다.

## 구현사항

* [ ] Firebase Admin SDK 연동
* [ ] FCM 설정 및 초기화 Config 구현
* [ ] FCM 전송 서비스 구현
* [x] Notification 기능과 FCM 기능 연동
* [x] Parent 및 Children 계열 엔티티에 FCM 토큰 저장 기능 추가
* [x] FCM 토큰 저장 및 갱신 API 구현
* [x] 테스트용 푸시 발송 API 구현
* [x] Silent Push 전송 기능 구현

## 추가 구현 완료 사항

* [x] MockFcmService 기반 Mock Push 구조 구현
* [x] FirebaseFcmService placeholder 구조 구현
* [x] Mission 이벤트 기반 자동 알림 및 Push 연동
* [x] 정책 변경 시 Silent Push 이벤트 연동
* [x] NotificationType 기반 Push Payload 구조 구현
* [x] memberRole 기반 부모/자녀 Push 분리 처리
* [x] Push 실패와 Notification 저장 실패 분리 처리
* [x] FcmMessageDto 기반 Payload 구조화
* [x] FCM 토큰 존재 여부 검증 후 Push 전송 처리

## 관련 이슈
- Relates to https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/39