### PR TITLE
Feat: FCM 실시간 푸시 알림 인프라 및 공통 발송 서비스 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### env file ###
 .env
+/src/main/resources/firebase/service-account.json

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
     implementation 'org.springframework.boot:spring-boot-configuration-processor'
+
+    //firebase
+    implementation 'com.google.firebase:firebase-admin:9.3.0'
 }
 
 // 6. 의존성 관리 (BOM): Spring AI와 관련된 수많은 하위 라이브러리들의 버전을 1.1.3으로 일관되게 맞춰주어 버전 충돌을 방지합니다.

--- a/src/main/java/me/sogom/bridge/domain/fcm/controller/FcmController.java
+++ b/src/main/java/me/sogom/bridge/domain/fcm/controller/FcmController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/fcm")
+@RequestMapping("/api/v1/fcm")
 @Tag(name = "FCM API")
 public class FcmController {
 

--- a/src/main/java/me/sogom/bridge/domain/fcm/service/FirebaseFcmService.java
+++ b/src/main/java/me/sogom/bridge/domain/fcm/service/FirebaseFcmService.java
@@ -1,16 +1,46 @@
 package me.sogom.bridge.domain.fcm.service;
 
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.sogom.bridge.domain.fcm.dto.message.FcmMessageDTO;
+import me.sogom.bridge.domain.member.entity.Children;
+import me.sogom.bridge.domain.member.entity.Parent;
+import me.sogom.bridge.domain.member.repository.ChildrenRepository;
+import me.sogom.bridge.domain.member.repository.ParentRepository;
 import me.sogom.bridge.global.security.entity.AuthMember;
 import me.sogom.bridge.global.security.entity.MemberRole;
+import org.springframework.stereotype.Service;
 
 @Slf4j
-//@Service  실제로 Firebase 연동 시 주석 처리 해제 및 MockFcmService의 @Service 해제
+@Service
+@RequiredArgsConstructor
 public class FirebaseFcmService implements FcmService {
 
-    // 실제 Firebase 연동 예정 서비스
-    // Firebase service-account.json 연결 후 구현 예정
+    private final ParentRepository parentRepository;
+    private final ChildrenRepository childrenRepository;
+
+    @Override
+    public void saveFcmToken(
+            AuthMember authMember,
+            String fcmToken
+    ) {
+
+        if (authMember.getRole() == MemberRole.PARENT) {
+            Parent parent = authMember.asParent();
+            parent.updateFcmToken(fcmToken);
+            parentRepository.save(parent);
+            return;
+        }
+
+        else if (authMember.getRole() == MemberRole.CHILDREN) {
+            Children children = authMember.asChildren();
+            children.updateFcmToken(fcmToken);
+            childrenRepository.save(children);
+            return;
+        }
+    }
 
     @Override
     public void sendPush(
@@ -19,7 +49,24 @@ public class FirebaseFcmService implements FcmService {
             FcmMessageDTO message
     ) {
 
-        log.info("Firebase 일반 푸시 전송 예정");
+        try {
+
+            String token = getFcmToken(memberId, memberRole);
+            if (token == null || token.isBlank()) {
+                return;
+            }
+            Message firebaseMessage = Message.builder()
+                    .setToken(token)
+                    .putData("title", message.title())
+                    .putData("body", message.body())
+                    .putData("type", message.type())
+                    .putData("targetId", String.valueOf(message.targetId()))
+                    .build();
+            FirebaseMessaging.getInstance().send(firebaseMessage);
+            log.info("Firebase Push 전송 완료");
+        } catch (Exception e) {
+            log.error("Firebase Push 전송 실패", e);
+        }
     }
 
     @Override
@@ -29,17 +76,40 @@ public class FirebaseFcmService implements FcmService {
             String type
     ) {
 
-        log.info("Firebase Silent Push 전송 예정");
+        try {
+
+            String token = getFcmToken(memberId, memberRole);
+            if (token == null || token.isBlank()) {
+                return;
+            }
+            Message firebaseMessage = Message.builder()
+                    .setToken(token)
+                    .putData("type", type)
+                    .build();
+            FirebaseMessaging.getInstance().send(firebaseMessage);
+            log.info("Firebase Silent Push 전송 완료");
+        } catch (Exception e) {
+            log.error("Firebase Silent Push 전송 실패", e);
+        }
     }
 
-    // Firebase 토큰 저장 예정
-    @Override
-    public void saveFcmToken(
-            AuthMember authMember,
-            String fcmToken
+    private String getFcmToken(
+            Long memberId,
+            MemberRole memberRole
     ) {
 
-        log.info("Firebase FCM 토큰 저장 예정");
-    }
+        if (memberRole == MemberRole.PARENT) {
+            Parent parent = parentRepository.findById(memberId)
+                    .orElseThrow(() -> new IllegalArgumentException("부모 회원을 찾을 수 없습니다."));
+            return parent.getFcmToken();
+        }
 
+        else if (memberRole == MemberRole.CHILDREN) {
+            Children children = childrenRepository.findById(memberId)
+                    .orElseThrow(() -> new IllegalArgumentException("자녀 회원을 찾을 수 없습니다."));
+            return children.getFcmToken();
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/fcm/service/MockFcmService.java
+++ b/src/main/java/me/sogom/bridge/domain/fcm/service/MockFcmService.java
@@ -9,12 +9,8 @@ import me.sogom.bridge.domain.member.repository.ChildrenRepository;
 import me.sogom.bridge.domain.member.repository.ParentRepository;
 import me.sogom.bridge.global.security.entity.AuthMember;
 import me.sogom.bridge.global.security.entity.MemberRole;
-import org.springframework.context.annotation.Primary;
-import org.springframework.stereotype.Service;
 
 @Slf4j
-@Service
-@Primary
 @RequiredArgsConstructor
 public class MockFcmService implements FcmService {
 

--- a/src/main/java/me/sogom/bridge/global/config/FirebaseConfig.java
+++ b/src/main/java/me/sogom/bridge/global/config/FirebaseConfig.java
@@ -1,0 +1,41 @@
+package me.sogom.bridge.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.InputStream;
+
+@Slf4j
+@Configuration
+public class FirebaseConfig {
+
+    @PostConstruct
+    public void initialize() {
+
+        try {
+
+            InputStream serviceAccount = getClass()
+                    .getClassLoader()
+                    .getResourceAsStream("firebase/service-account.json");
+
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+
+            if (FirebaseApp.getApps().isEmpty()) {
+
+                FirebaseApp.initializeApp(options);
+
+                log.info("Firebase 초기화 완료");
+            }
+
+        } catch (Exception e) {
+
+            log.error("Firebase 초기화 실패", e);
+        }
+    }
+}


### PR DESCRIPTION
## 설명

기존 Notification CRUD 기능에 Firebase Cloud Messaging 기반 푸시 알림 기능을 추가한다.
현재 구현된 Notification 저장 및 미션 이벤트 알림 기능과 연동하여 특정 이벤트 발생 시 실제 사용자 디바이스로 푸시 알림을 전송할 수 있도록 구현한다.
Flutter 앱에서 발급한 FCM 토큰을 서버에 저장하고, 미션 관련 이벤트 발생 시 Notification 저장과 함께 푸시 알림이 전송되도록 구성한다.

## 참고사항

Firebase Admin SDK 연동 및 Firebase 초기화까지 완료했으며 FirebaseMessaging.send() 호출까지 확인 완료했습니다.

현재 실제 Flutter FCM token 및 실제 디바이스 Push 수신 테스트는 미연동 상태이며, 현재는 Mock token 기반 테스트 환경입니다.

실제 디바이스 Push 수신 테스트는 Flutter 측 실제 FCM token 연동 이후 진행 예정입니다.

## 구현사항

* [x] Firebase Admin SDK 연동
* [x] FCM 설정 및 초기화 Config 구현
* [x] FCM 전송 서비스 구현
* [x] Notification 기능과 FCM 기능 연동
* [x] Parent 및 Children 계열 엔티티에 FCM 토큰 저장 기능 추가
* [x] FCM 토큰 저장 및 갱신 API 구현
* [x] 테스트용 푸시 발송 API 구현
* [x] Silent Push 전송 기능 구현

## 추가 구현 완료 사항

* [x] MockFcmService 기반 Mock Push 구조 구현
* [x] FirebaseFcmService 기반 실제 Firebase 연동 구조 구현
* [x] Mission 이벤트 기반 자동 알림 및 Push 연동
* [x] 정책 변경 시 Silent Push 이벤트 연동
* [x] NotificationType 기반 Push Payload 구조 구현
* [x] memberRole 기반 부모/자녀 Push 분리 처리
* [x] Push 실패와 Notification 저장 실패 분리 처리
* [x] FcmMessageDTO 기반 Payload 구조화
* [x] FCM 토큰 존재 여부 검증 후 Push 전송 처리
* [x] Firebase data payload 기반 Silent Push 구조 구현

## 테스트 완료 사항

* [x] Firebase 초기화 성공 확인
* [x] FirebaseMessaging.send() 호출 확인
* [x] FCM 토큰 저장 API 테스트 완료
* [x] 테스트 Push API 동작 확인
* [x] Mission 이벤트 기반 Notification 및 Push 호출 확인
* [x] 정책 변경 기반 Silent Push 호출 확인
* [x] Mock Push 로그 테스트 완료

## 관련 이슈

* Closes https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/39
* Relates to https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/39