### PR TITLE
Feat: 3.1 미션 목록 조회 api에 자녀 조회 기능 추가

### DIFF
--- a/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
@@ -8,11 +8,16 @@ import me.sogom.bridge.domain.mission.dto.req.MissionReqDTO;
 import me.sogom.bridge.domain.mission.dto.res.MissionPerformanceResDTO;
 import me.sogom.bridge.domain.mission.dto.res.MissionResDTO;
 import me.sogom.bridge.domain.mission.entity.MissionCategory;
-import me.sogom.bridge.domain.mission.service.MissionPerformanceService; // 변경: 통합 서비스 임포트
+import me.sogom.bridge.domain.mission.exception.MissionErrorCode;
+import me.sogom.bridge.domain.mission.exception.MissionException;
+import me.sogom.bridge.domain.mission.service.MissionPerformanceService;
 import me.sogom.bridge.domain.mission.service.MissionService;
 import me.sogom.bridge.global.apiPayload.ApiResponse;
+import me.sogom.bridge.global.apiPayload.code.GeneralErrorCode;
 import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
+import me.sogom.bridge.global.apiPayload.exception.ProjectException;
 import me.sogom.bridge.global.security.entity.AuthMember;
+import me.sogom.bridge.global.security.entity.MemberRole;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*; // PathVariable 등을 위해 추가
@@ -41,14 +46,32 @@ public class MissionController {
         return ApiResponse.onSuccess(MissionSuccessCode.MISSION_CREATE_SUCCESS, response);
     }
 
-    //부모의 미션 목록 조회 API
+    //부모/자녀의 미션 목록 조회 API
     @GetMapping
     public ApiResponse<List<MissionResDTO.MissionSummaryResponse>> getMissionList(
             @AuthenticationPrincipal AuthMember authMember,
-            @RequestParam("childId") Long childId) {
+            @RequestParam(value = "childId", required = false) Long childId) {
 
-        Long parentId = authMember.asParent().getId();
-        List<MissionResDTO.MissionSummaryResponse> response = missionService.getParentMissionSummaries(parentId, childId);
+        List<MissionResDTO.MissionSummaryResponse> response;
+
+        if (authMember.getRole() == MemberRole.PARENT) {
+
+            if (childId == null) {
+                throw new MissionException(MissionErrorCode.CHILD_PARENT_MISMATCH);
+            }
+
+            Long parentId = authMember.asParent().getId();
+            response = missionService.getParentMissionSummaries(parentId, childId);
+
+        } else if (authMember.getRole() == MemberRole.CHILDREN) {
+
+            Long childrenId = authMember.asChildren().getId();
+            response = missionService.getChildrenMissionSummaries(childrenId);
+
+        } else {
+            throw new ProjectException(GeneralErrorCode.FORBIDDEN);
+        }
+
         return ApiResponse.onSuccess(MissionSuccessCode.MISSION_LIST_SUCCESS, response);
     }
 

--- a/src/main/java/me/sogom/bridge/domain/mission/repository/MissionSettingRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/repository/MissionSettingRepository.java
@@ -26,4 +26,18 @@ public interface MissionSettingRepository extends JpaRepository<MissionSetting, 
             order by m.id desc
             """)
     List<MissionResDTO.MissionSummaryResponse> findMissionSummariesByParentIdAndChildId(Long parentId, Long childId);
+
+    @Query("""
+        select new me.sogom.bridge.domain.mission.dto.res.MissionResDTO$MissionSummaryResponse(
+            m.id,
+            m.title,
+            s.category,
+            s.reward
+        )
+        from MissionSetting s
+        join s.mission m
+        where m.child.id = :childId
+        order by m.id desc
+        """)
+    List<MissionResDTO.MissionSummaryResponse> findMissionSummariesByChildId(Long childId);
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/repository/MissionSettingRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/repository/MissionSettingRepository.java
@@ -13,7 +13,7 @@ public interface MissionSettingRepository extends JpaRepository<MissionSetting, 
     Optional<MissionSetting> findByMissionId(Long missionId);
 
     @Query("""
-            select new me.sogom.bridge.domain.mission.dto.res.MissionResDTO$MissionSummaryResponse(
+            select new me.sogom.bridge.domain.mission.dto.res.MissionResDTO.MissionSummaryResponse(
                 m.id,
                 m.title,
                 s.category,
@@ -28,7 +28,7 @@ public interface MissionSettingRepository extends JpaRepository<MissionSetting, 
     List<MissionResDTO.MissionSummaryResponse> findMissionSummariesByParentIdAndChildId(Long parentId, Long childId);
 
     @Query("""
-        select new me.sogom.bridge.domain.mission.dto.res.MissionResDTO$MissionSummaryResponse(
+        select new me.sogom.bridge.domain.mission.dto.res.MissionResDTO.MissionSummaryResponse(
             m.id,
             m.title,
             s.category,

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionService.java
@@ -104,4 +104,13 @@ public class MissionService {
 
         return MissionResDTO.MissionResponse.of(mission, setting);
     }
+
+    @Transactional(readOnly = true)
+    public List<MissionResDTO.MissionSummaryResponse> getChildrenMissionSummaries(Long childrenId) {
+
+        Children child = childrenRepository.findById(childrenId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.CHILDREN_NOT_FOUND));
+
+        return missionSettingRepository.findMissionSummariesByChildId(child.getId());
+    }
 }


### PR DESCRIPTION
## 설명
기존 GET /api/v1/missions API는 부모 권한(PARENT)만 허용하고 있어 자녀앱에서 미션 목록 조회가 불가능한 문제가 있었다.
이번 PR에서는 CHILDREN 권한에서도 본인 미션 목록을 조회할 수 있도록 권한 분기를 추가하였다.
기존 부모 조회 로직 및 응답 DTO 구조는 유지하며, 자녀는 JWT 기반으로 자신의 미션만 조회 가능하도록 제한하였다.

## 변경사항
- [x] MissionController
- [x] MissionSettingRepository
- [x] MissionService

## 관련 이슈
- Closes https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/45
- Relates to https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/45