### PR TITLE
Fix: 미션 수행 사진 제출 API multipart 단순화 및 서버 내부 파생 처리

### DIFF
--- a/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
@@ -8,11 +8,16 @@ import me.sogom.bridge.domain.mission.dto.req.MissionReqDTO;
 import me.sogom.bridge.domain.mission.dto.res.MissionPerformanceResDTO;
 import me.sogom.bridge.domain.mission.dto.res.MissionResDTO;
 import me.sogom.bridge.domain.mission.entity.MissionCategory;
-import me.sogom.bridge.domain.mission.service.MissionPerformanceService; // 변경: 통합 서비스 임포트
+import me.sogom.bridge.domain.mission.exception.MissionErrorCode;
+import me.sogom.bridge.domain.mission.exception.MissionException;
+import me.sogom.bridge.domain.mission.service.MissionPerformanceService;
 import me.sogom.bridge.domain.mission.service.MissionService;
 import me.sogom.bridge.global.apiPayload.ApiResponse;
+import me.sogom.bridge.global.apiPayload.code.GeneralErrorCode;
 import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
+import me.sogom.bridge.global.apiPayload.exception.ProjectException;
 import me.sogom.bridge.global.security.entity.AuthMember;
+import me.sogom.bridge.global.security.entity.MemberRole;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*; // PathVariable 등을 위해 추가
@@ -41,14 +46,32 @@ public class MissionController {
         return ApiResponse.onSuccess(MissionSuccessCode.MISSION_CREATE_SUCCESS, response);
     }
 
-    //부모의 미션 목록 조회 API
+    //부모/자녀의 미션 목록 조회 API
     @GetMapping
     public ApiResponse<List<MissionResDTO.MissionSummaryResponse>> getMissionList(
             @AuthenticationPrincipal AuthMember authMember,
-            @RequestParam("childId") Long childId) {
+            @RequestParam(value = "childId", required = false) Long childId) {
 
-        Long parentId = authMember.asParent().getId();
-        List<MissionResDTO.MissionSummaryResponse> response = missionService.getParentMissionSummaries(parentId, childId);
+        List<MissionResDTO.MissionSummaryResponse> response;
+
+        if (authMember.getRole() == MemberRole.PARENT) {
+
+            if (childId == null) {
+                throw new MissionException(MissionErrorCode.CHILD_PARENT_MISMATCH);
+            }
+
+            Long parentId = authMember.asParent().getId();
+            response = missionService.getParentMissionSummaries(parentId, childId);
+
+        } else if (authMember.getRole() == MemberRole.CHILDREN) {
+
+            Long childrenId = authMember.asChildren().getId();
+            response = missionService.getChildrenMissionSummaries(childrenId);
+
+        } else {
+            throw new ProjectException(GeneralErrorCode.FORBIDDEN);
+        }
+
         return ApiResponse.onSuccess(MissionSuccessCode.MISSION_LIST_SUCCESS, response);
     }
 

--- a/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
@@ -7,7 +7,6 @@ import me.sogom.bridge.domain.mission.dto.AiVerificationResponse;
 import me.sogom.bridge.domain.mission.dto.req.MissionReqDTO;
 import me.sogom.bridge.domain.mission.dto.res.MissionPerformanceResDTO;
 import me.sogom.bridge.domain.mission.dto.res.MissionResDTO;
-import me.sogom.bridge.domain.mission.entity.MissionCategory;
 import me.sogom.bridge.domain.mission.exception.MissionErrorCode;
 import me.sogom.bridge.domain.mission.exception.MissionException;
 import me.sogom.bridge.domain.mission.service.MissionPerformanceService;
@@ -20,7 +19,7 @@ import me.sogom.bridge.global.security.entity.AuthMember;
 import me.sogom.bridge.global.security.entity.MemberRole;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*; // PathVariable 등을 위해 추가
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -88,13 +87,11 @@ public class MissionController {
     @PostMapping(value = "/{missionId}/performances", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<AiVerificationResponse> performMission(
             @PathVariable("missionId") Long missionId,      // 어떤 미션인지 (경로 변수)
-            @RequestParam("childId") Long childId,          // 수행하는 자녀가 누구인지
-            @RequestParam("image") MultipartFile image,     // 인증 사진
-            @RequestParam("category") MissionCategory category, //카테고리
-            @RequestParam("prompt") String prompt) throws IOException {
-
+            @AuthenticationPrincipal AuthMember authMember, // member JWT token
+            @RequestParam("image") MultipartFile image ) throws IOException {   // 인증 사진
+        Long childId = authMember.asChildren().getId();     // 수행하는 자녀가 누구인지 token에서 가져옴
         // Service에서 권한 검증 -> AI 판독 -> DB 저장(reason 포함)을 한 번에 처리 후 결과 반환
-        AiVerificationResponse result = performanceService.verifyAndSaveMission(missionId, childId, image, prompt, category);
+        AiVerificationResponse result = performanceService.verifyAndSaveMission( missionId, childId, image );
         // APIResponse 포맷으로 반환
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, result);
     }

--- a/src/main/java/me/sogom/bridge/domain/mission/repository/MissionSettingRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/repository/MissionSettingRepository.java
@@ -26,4 +26,18 @@ public interface MissionSettingRepository extends JpaRepository<MissionSetting, 
             order by m.id desc
             """)
     List<MissionResDTO.MissionSummaryResponse> findMissionSummariesByParentIdAndChildId(Long parentId, Long childId);
+
+    @Query("""
+        select new me.sogom.bridge.domain.mission.dto.res.MissionResDTO$MissionSummaryResponse(
+            m.id,
+            m.title,
+            s.category,
+            s.reward
+        )
+        from MissionSetting s
+        join s.mission m
+        where m.child.id = :childId
+        order by m.id desc
+        """)
+    List<MissionResDTO.MissionSummaryResponse> findMissionSummariesByChildId(Long childId);
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/repository/MissionSettingRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/repository/MissionSettingRepository.java
@@ -13,7 +13,7 @@ public interface MissionSettingRepository extends JpaRepository<MissionSetting, 
     Optional<MissionSetting> findByMissionId(Long missionId);
 
     @Query("""
-            select new me.sogom.bridge.domain.mission.dto.res.MissionResDTO$MissionSummaryResponse(
+            select new me.sogom.bridge.domain.mission.dto.res.MissionResDTO.MissionSummaryResponse(
                 m.id,
                 m.title,
                 s.category,
@@ -28,7 +28,7 @@ public interface MissionSettingRepository extends JpaRepository<MissionSetting, 
     List<MissionResDTO.MissionSummaryResponse> findMissionSummariesByParentIdAndChildId(Long parentId, Long childId);
 
     @Query("""
-        select new me.sogom.bridge.domain.mission.dto.res.MissionResDTO$MissionSummaryResponse(
+        select new me.sogom.bridge.domain.mission.dto.res.MissionResDTO.MissionSummaryResponse(
             m.id,
             m.title,
             s.category,

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
@@ -38,7 +38,7 @@ public class MissionPerformanceService {
     private final NotificationService notificationService;
 
     @Transactional // 데이터를 DB에 반영하기 위해 반드시 필요
-    public AiVerificationResponse verifyAndSaveMission(Long missionId, Long childId, MultipartFile image, String prompt, MissionCategory category) throws IOException {
+    public AiVerificationResponse verifyAndSaveMission( Long missionId, Long childId, MultipartFile image ) throws IOException {
         //미션과 자녀 정보 조회 (예외 던지기 적용)
         Mission mission = missionRepository.findById(missionId)
                 .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
@@ -72,6 +72,8 @@ public class MissionPerformanceService {
         // 미션 설정 정보 조회
         MissionSetting setting = missionSettingRepository.findByMissionId(missionId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
+        MissionCategory category = setting.getCategory();   //카테고리를 미션id로 받아옴
+        String prompt = setting.getDescription();   //부모가 미션 세팅 시 미션 설명 적은걸 가져옴
 
         // 미션 인증 방식 조회
         VerificationType verificationType = setting.getVerificationType();

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPromptProvider.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPromptProvider.java
@@ -14,15 +14,10 @@ public class MissionPromptProvider {
             MissionCategory.STUDY, "사진에 펼쳐진 책, 필기구, 노트 등 공부를 한 명확한 증거가 있는지 분석해 줘. 덜 풀린 문제가 있는 경우엔 fail 처리 해줘",
             MissionCategory.EXERCISE, "사진에 헬스장, 운동 기구, 혹은 운동복을 입고 운동 중인 모습 등 명확한 증거가 있는지 분석해 줘. 등장하는 인물이 있다면 운동을 한 모습인지 분석해줘",
             MissionCategory.ERRAND, "사진에 구매한 물품, 영수증, 심부름 장소(마트, 우체국 등)의 배경, 또는 심부름을 수행 중인 명확한 증거가 있는지 분석해 줘. 요청받은 심부름 내용과 사진 속 물품이 일치하지 않는 경우엔 fail 처리 해줘.",
-            MissionCategory.ROUTINE, "사진에 영양제/물 섭취, 일기장 작성, 기상 인증 등 부모가 입력한 미션에 대해 완수한 명확한 증거가 있는지 분석해 줘. 무관한 일상 사진이거나 성의가 없는 경우엔 fail 처리 해줘.",
-            MissionCategory.ETC, "주어진 사진이 특정 미션을 성공적으로 완수한 모습인지 일반적인 기준으로 분석해 줘."
+            MissionCategory.ROUTINE, "사진에 영양제/물 섭취, 일기장 작성, 기상 인증 등 부모가 입력한 미션에 대해 완수한 명확한 증거가 있는지 분석해 줘. 무관한 일상 사진이거나 성의가 없는 경우엔 fail 처리 해줘."
     );
 
-    public String getPrompt(MissionCategory category) {
-        // 카테고리가 null이거나 목록에 없으면 ETC(기타) 프롬프트를 기본으로 반환
-        if (category == null || !PROMPTS.containsKey(category)) {
-            return PROMPTS.get(MissionCategory.ETC);
-        }
-        return PROMPTS.get(category);
-    }
+    public String getPrompt(MissionCategory category) { if (category == null || !PROMPTS.containsKey(category)) {
+        throw new IllegalArgumentException("유효하지 않은 미션 카테고리입니다."); }
+        return PROMPTS.get(category); }
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionService.java
@@ -104,4 +104,13 @@ public class MissionService {
 
         return MissionResDTO.MissionResponse.of(mission, setting);
     }
+
+    @Transactional(readOnly = true)
+    public List<MissionResDTO.MissionSummaryResponse> getChildrenMissionSummaries(Long childrenId) {
+
+        Children child = childrenRepository.findById(childrenId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.CHILDREN_NOT_FOUND));
+
+        return missionSettingRepository.findMissionSummariesByChildId(child.getId());
+    }
 }


### PR DESCRIPTION
## 설명

현재 `POST /api/v1/missions/{missionId}/performances` API는 multipart/form-data 요청 시 `childId`, `category`, `prompt`, `image` 를 모두 요구하고 있다.

하지만 앱은 미션 수행 사진 제출 흐름을 단순화하기 위해, 캡처 사진 파일(`image`)만 직접 업로드하는 구조로 변경되었다.
기존 `/uploads/photo` 기반 2단계 업로드 흐름은 제거된 상태이다.

백엔드에서 나머지 값들을 내부적으로 파생하여, `image` 파일만으로 미션 인증이 동작할 수 있도록 수정한다.

추가로 프론트에서 제시하지 않은 ETC ENUM을 삭제하고 그에 따른 예외처리를 변경했다.

## 변경 사항
MissionController.java 입력 파라미터 변경
MissionPerformanceService.java 내부에서 카테고리와 프롬프트를 받아오도록 처리
MissionPromptProvider.java ENUM 변경 및 예외처리 throw 변경

## 관련 이슈
- Closes https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/46
- Relates to https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/46
