### PR TITLE
Fix : 로그인 응답수정 및 필드 optional화

### DIFF
--- a/src/main/java/me/sogom/bridge/domain/member/controller/ParentController.java
+++ b/src/main/java/me/sogom/bridge/domain/member/controller/ParentController.java
@@ -28,12 +28,12 @@ public class ParentController {
      * @return 자녀 등록 성공 응답
      */
     @PostMapping("/children")
-    public ApiResponse<Void> registerChild(
+    public ApiResponse<MemberResDTO.ChildrenInfoResponse> registerChild(
             @AuthenticationPrincipal AuthMember authMember,
             @RequestBody @Valid MemberReqDTO.RegisterChildRequest request) {
         Long parentId = authMember.getMember().getId();
-        parentService.registerChild(parentId, request);
-        return ApiResponse.onSuccess(MemberSuccessCode.CHILDREN_REGISTER_SUCCESS, null);
+        MemberResDTO.ChildrenInfoResponse response = parentService.registerChild(parentId, request);
+        return ApiResponse.onSuccess(MemberSuccessCode.CHILDREN_REGISTER_SUCCESS, response);
     }
 
     /**

--- a/src/main/java/me/sogom/bridge/domain/member/dto/req/MemberReqDTO.java
+++ b/src/main/java/me/sogom/bridge/domain/member/dto/req/MemberReqDTO.java
@@ -1,5 +1,6 @@
 package me.sogom.bridge.domain.member.dto.req;
 
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -55,7 +56,7 @@ public class MemberReqDTO {
             @NotBlank(message = "자녀 이름을 입력해 주세요.")
             String childrenName,
 
-            @NotBlank(message = "자녀 출생연도를 입력해 주세요.")
+            @Nullable
             String childrenBirth,
 
             @NotBlank(message = "자녀 코드를 입력해 주세요.")

--- a/src/main/java/me/sogom/bridge/domain/member/dto/res/MemberResDTO.java
+++ b/src/main/java/me/sogom/bridge/domain/member/dto/res/MemberResDTO.java
@@ -11,7 +11,9 @@ public class MemberResDTO {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record AuthResponse(
         @Nullable String accessToken,
-        @Nullable String refreshToken
+        @Nullable String refreshToken,
+        @Nullable Long memberId,
+        @Nullable String name
     ) {}
 
     @Builder

--- a/src/main/java/me/sogom/bridge/domain/member/entity/Children.java
+++ b/src/main/java/me/sogom/bridge/domain/member/entity/Children.java
@@ -35,7 +35,7 @@ public class Children extends BaseEntity implements Member {
     @Column
     private LocalDateTime passwordChangedAt;
 
-    @Column(length = 8)
+    @Column(length = 8, unique = true)
     private String code; // 자녀 연동 코드
 
     @Column(length = 4)

--- a/src/main/java/me/sogom/bridge/domain/member/entity/Member.java
+++ b/src/main/java/me/sogom/bridge/domain/member/entity/Member.java
@@ -4,4 +4,5 @@ public interface Member {
     Long getId();
     String getEmail();
     String getHash();
+    String getName();
 }

--- a/src/main/java/me/sogom/bridge/domain/member/service/AuthService.java
+++ b/src/main/java/me/sogom/bridge/domain/member/service/AuthService.java
@@ -6,6 +6,7 @@ import me.sogom.bridge.domain.member.MemberException;
 import me.sogom.bridge.domain.member.dto.req.MemberReqDTO;
 import me.sogom.bridge.domain.member.dto.res.MemberResDTO;
 import me.sogom.bridge.domain.member.entity.Children;
+import me.sogom.bridge.domain.member.entity.Member;
 import me.sogom.bridge.domain.member.entity.MemberStatus;
 import me.sogom.bridge.domain.member.entity.Parent;
 import me.sogom.bridge.domain.member.entity.RefreshToken;
@@ -41,7 +42,7 @@ public class AuthService {
                 .hash(passwordEncoder.encode(request.password()))
                 .build();
         parentRepository.save(parent);
-        return new MemberResDTO.AuthResponse(null, null);
+        return new MemberResDTO.AuthResponse(null, null, null, null);
     }
 
     @Transactional
@@ -56,7 +57,7 @@ public class AuthService {
                 .code(code)
                 .build();
         childrenRepository.save(children);
-        return new MemberResDTO.AuthResponse(null, null);
+        return new MemberResDTO.AuthResponse(null, null, null, null);
     }
 
     @Transactional
@@ -116,12 +117,14 @@ public class AuthService {
                 .expiresAt(expiresAt)
                 .build());
 
-        return new MemberResDTO.AuthResponse(accessToken, refreshTokenValue);
+        Member member = authMember.getMember();
+        return new MemberResDTO.AuthResponse(accessToken, refreshTokenValue, member.getId(), member.getName());
     }
 
     private MemberResDTO.AuthResponse issueAccessTokenOnly(AuthMember authMember) {
         String accessToken = jwtUtil.createAccessToken(authMember);
-        return new MemberResDTO.AuthResponse(accessToken, null);
+        Member member = authMember.getMember();
+        return new MemberResDTO.AuthResponse(accessToken, null, member.getId(), member.getName());
     }
 
     private AuthMember loadAuthMember(String email, MemberRole role) {

--- a/src/main/java/me/sogom/bridge/domain/member/service/AuthService.java
+++ b/src/main/java/me/sogom/bridge/domain/member/service/AuthService.java
@@ -14,6 +14,8 @@ import me.sogom.bridge.domain.member.repository.ChildrenRepository;
 import me.sogom.bridge.domain.member.repository.ParentRepository;
 import me.sogom.bridge.domain.member.repository.RefreshTokenRepository;
 import me.sogom.bridge.domain.member.util.ChildrenCodeGenerator;
+import me.sogom.bridge.global.apiPayload.code.GeneralErrorCode;
+import me.sogom.bridge.global.apiPayload.exception.ProjectException;
 import me.sogom.bridge.global.security.entity.AuthMember;
 import me.sogom.bridge.global.security.entity.MemberRole;
 import me.sogom.bridge.global.security.util.JwtUtil;
@@ -49,7 +51,7 @@ public class AuthService {
     public MemberResDTO.AuthResponse signUpChildren(MemberReqDTO.SignUpRequest request) {
         checkDuplicateEmail(request.email());
 
-        String code = ChildrenCodeGenerator.generateCode();
+        String code = generateUniqueChildrenCode();
         Children children = Children.builder()
                 .name(request.name())
                 .email(request.email())
@@ -58,6 +60,18 @@ public class AuthService {
                 .build();
         childrenRepository.save(children);
         return new MemberResDTO.AuthResponse(null, null, null, null);
+    }
+
+    private static final int CHILDREN_CODE_MAX_ATTEMPTS = 5;
+
+    private String generateUniqueChildrenCode() {
+        for (int i = 0; i < CHILDREN_CODE_MAX_ATTEMPTS; i++) {
+            String candidate = ChildrenCodeGenerator.generateCode();
+            if (childrenRepository.findByCode(candidate).isEmpty()) {
+                return candidate;
+            }
+        }
+        throw new ProjectException(GeneralErrorCode.INTERNAL_SERVER_ERROR);
     }
 
     @Transactional

--- a/src/main/java/me/sogom/bridge/domain/member/service/ParentService.java
+++ b/src/main/java/me/sogom/bridge/domain/member/service/ParentService.java
@@ -38,7 +38,7 @@ public class ParentService {
      * @param request 자녀 등록 요청 (자녀 이름, 자녀 코드, 프로필 사진 URL)
      */
     @Transactional
-    public void registerChild(Long parentId, MemberReqDTO.RegisterChildRequest request) {
+    public MemberResDTO.ChildrenInfoResponse registerChild(Long parentId, MemberReqDTO.RegisterChildRequest request) {
         Parent parent = parentRepository.findById(parentId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
@@ -58,6 +58,8 @@ public class ParentService {
         childrenRepository.save(children);
         parent.getChildren().add(children);
         parentRepository.save(parent);
+
+        return MemberResDTO.ChildrenInfoResponse.of(children);
     }
 
     /**

--- a/src/main/java/me/sogom/bridge/domain/member/util/ChildrenCodeGenerator.java
+++ b/src/main/java/me/sogom/bridge/domain/member/util/ChildrenCodeGenerator.java
@@ -1,12 +1,12 @@
 package me.sogom.bridge.domain.member.util;
 
-import java.util.Random;
+import java.security.SecureRandom;
 
 public class ChildrenCodeGenerator {
 
     private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     private static final int CODE_LENGTH = 8;
-    private static final Random RANDOM = new Random();
+    private static final SecureRandom RANDOM = new SecureRandom();
 
     /**
      * 자녀 연동 코드 생성 (영문 대문자 + 숫자 조합, 8자리)


### PR DESCRIPTION
## 주요 변경 사항

- 로그인 시, memberId 및 name 반환 추가
- 자녀 등록 시, birth optional화
- 자녀코드 생성 secureRandom으로 변경

## 관련 이슈/마일스톤

<!-- Close 키워드로 연결하면 머지 시 자동 종료됩니다. -->

<!-- 예: Closes #1, Relates to #2 / Milestone: 2025-12 Sprint 4 -->

- Closes #49 
- Relates to #49 