### PR TITLE
[codex] Expose child code in member responses

### DIFF
--- a/src/main/java/me/sogom/bridge/domain/member/dto/res/MemberResDTO.java
+++ b/src/main/java/me/sogom/bridge/domain/member/dto/res/MemberResDTO.java
@@ -13,23 +13,25 @@ public class MemberResDTO {
         @Nullable String accessToken,
         @Nullable String refreshToken,
         @Nullable Long memberId,
-        @Nullable String name
+        @Nullable String name,
+        @Nullable String childCode
     ) {}
 
     @Builder
     public record
     ChildrenInfoResponse(
             @JsonProperty("childrenId") Long childrenId,
+            @JsonProperty("childCode") String childCode,
             @JsonProperty("name") String name,
             @JsonProperty("profileImageUrl") String profileImageUrl
     ) {
         public static ChildrenInfoResponse of(Children children, String profileImageUrl) {
             return ChildrenInfoResponse.builder()
                     .childrenId(children.getId())
+                    .childCode(children.getCode())
                     .name(children.getName())
                     .profileImageUrl(profileImageUrl)
                     .build();
         }
     }
 }
-

--- a/src/main/java/me/sogom/bridge/domain/member/service/AuthService.java
+++ b/src/main/java/me/sogom/bridge/domain/member/service/AuthService.java
@@ -44,7 +44,7 @@ public class AuthService {
                 .hash(passwordEncoder.encode(request.password()))
                 .build();
         parentRepository.save(parent);
-        return new MemberResDTO.AuthResponse(null, null, null, null);
+        return new MemberResDTO.AuthResponse(null, null, null, null, null);
     }
 
     @Transactional
@@ -59,7 +59,13 @@ public class AuthService {
                 .code(code)
                 .build();
         childrenRepository.save(children);
-        return new MemberResDTO.AuthResponse(null, null, null, null);
+        return new MemberResDTO.AuthResponse(
+                null,
+                null,
+                children.getId(),
+                children.getName(),
+                children.getCode()
+        );
     }
 
     private static final int CHILDREN_CODE_MAX_ATTEMPTS = 5;
@@ -132,13 +138,41 @@ public class AuthService {
                 .build());
 
         Member member = authMember.getMember();
-        return new MemberResDTO.AuthResponse(accessToken, refreshTokenValue, member.getId(), member.getName());
+        return new MemberResDTO.AuthResponse(
+                accessToken,
+                refreshTokenValue,
+                member.getId(),
+                member.getName(),
+                childCodeOrNull(member)
+        );
     }
 
     private MemberResDTO.AuthResponse issueAccessTokenOnly(AuthMember authMember) {
         String accessToken = jwtUtil.createAccessToken(authMember);
         Member member = authMember.getMember();
-        return new MemberResDTO.AuthResponse(accessToken, null, member.getId(), member.getName());
+        return new MemberResDTO.AuthResponse(
+                accessToken,
+                null,
+                member.getId(),
+                member.getName(),
+                childCodeOrNull(member)
+        );
+    }
+
+    private String childCodeOrNull(Member member) {
+        if (member instanceof Children children) {
+            return ensureChildrenCode(children);
+        }
+        return null;
+    }
+
+    private String ensureChildrenCode(Children children) {
+        if (children.getCode() != null && !children.getCode().isBlank()) {
+            return children.getCode();
+        }
+        String code = generateUniqueChildrenCode();
+        children.setCode(code);
+        return code;
     }
 
     private AuthMember loadAuthMember(String email, MemberRole role) {

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -10,3 +10,10 @@ spring:
     hibernate:
       # 테스트 실행 시마다 테이블을 새로 만들고 종료 시 삭제합니다.
       ddl-auto: create-drop
+
+jwt:
+  token:
+    secret: test-jwt-secret-key-for-bridge-application-context-loads-1234567890
+    expiration:
+      access: 3600000
+      refresh: 1209600000

--- a/src/test/java/me/sogom/bridge/BridgeApplicationTests.java
+++ b/src/test/java/me/sogom/bridge/BridgeApplicationTests.java
@@ -2,8 +2,10 @@ package me.sogom.bridge;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class BridgeApplicationTests {
 
     @Test

--- a/src/test/java/me/sogom/bridge/domain/member/dto/res/MemberResDTOTest.java
+++ b/src/test/java/me/sogom/bridge/domain/member/dto/res/MemberResDTOTest.java
@@ -1,0 +1,40 @@
+package me.sogom.bridge.domain.member.dto.res;
+
+import me.sogom.bridge.domain.member.entity.Children;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberResDTOTest {
+
+    @Test
+    void authResponseCarriesChildCodeForChildMembers() {
+        MemberResDTO.AuthResponse response = new MemberResDTO.AuthResponse(
+                null,
+                null,
+                1L,
+                "Child",
+                "AB12CD34"
+        );
+
+        assertThat(response.childCode()).isEqualTo("AB12CD34");
+    }
+
+    @Test
+    void childrenInfoResponseIncludesChildCode() {
+        Children children = Children.builder()
+                .id(1L)
+                .name("Child")
+                .email("child@example.com")
+                .hash("hash")
+                .code("AB12CD34")
+                .build();
+
+        MemberResDTO.ChildrenInfoResponse response =
+                MemberResDTO.ChildrenInfoResponse.of(children, null);
+
+        assertThat(response.childrenId()).isEqualTo(1L);
+        assertThat(response.childCode()).isEqualTo("AB12CD34");
+        assertThat(response.name()).isEqualTo("Child");
+    }
+}


### PR DESCRIPTION
## Summary
- Expose `childCode` on child auth responses so the child app can display the pairing code generated at signup.
- Include `childCode` on parent child list/register responses so parent app state can retain the pairing identifier.
- Backfill missing active child codes lazily during child login/refresh responses.
- Make the Spring context test use the `test` profile and provide test-only JWT settings so `gradlew test` runs without local PostgreSQL/env secrets.

## Root Cause
The backend already generated and stored `Children.code`, and parent registration already looked up children by that code. However, the code was not included in `AuthResponse` or `ChildrenInfoResponse`, so apps could not retrieve or display it.

## Validation
- Installed Java 21 with Homebrew and ran tests using `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home`.
- `bash ./gradlew test` passed.
- `git diff --check` passed.
