### PR TITLE
시간 플로우 재정렬 및 알림/미션 API 보강

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # 2026-Bridge-quadS
 GDGoC 연합 프로젝트 quadS General Track Team Bridge의 코드 저장소
+
+## Local Backend
+
+```bash
+export LOCAL_DB_PASSWORD=bridge_local
+export JWT_SECRET_KEY='<jwt-secret>'
+export GEMINI_API_KEY='<gemini-api-key-or-dummy-for-non-ai-flows>'
+export AWS_S3_BUCKET='<s3-bucket-or-dummy-for-non-upload-flows>'
+
+docker compose up -d postgres
+JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH bash ./gradlew bootRun
+```
+
+The default local profile uses `jdbc:postgresql://localhost:5432/postgres`
+with user `postgres`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: bridge-local-postgres
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${LOCAL_DB_PASSWORD:-bridge_local}
+    ports:
+      - "5432:5432"
+    volumes:
+      - bridge-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  bridge-postgres-data:

--- a/src/main/java/me/sogom/bridge/domain/fcm/dto/message/FcmMessageDTO.java
+++ b/src/main/java/me/sogom/bridge/domain/fcm/dto/message/FcmMessageDTO.java
@@ -2,6 +2,9 @@ package me.sogom.bridge.domain.fcm.dto.message;
 
 import lombok.Builder;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 @Builder
 public record FcmMessageDTO(
 
@@ -11,7 +14,42 @@ public record FcmMessageDTO(
 
         String type,
 
-        Long targetId
+        Long targetId,
+
+        Long childId,
+
+        Long missionId,
+
+        Long performanceId,
+
+        String deeplink
 
 ) {
+
+    public Map<String, String> dataPayload() {
+        Map<String, String> payload = new LinkedHashMap<>();
+        putIfPresent(payload, "title", title);
+        putIfPresent(payload, "body", body);
+        putIfPresent(payload, "type", type);
+        putIfPresent(payload, "notificationType", type);
+        putIfPresent(payload, "targetId", targetId);
+        putIfPresent(payload, "notificationId", targetId);
+        putIfPresent(payload, "childId", childId);
+        putIfPresent(payload, "childrenId", childId);
+        putIfPresent(payload, "missionId", missionId);
+        putIfPresent(payload, "performanceId", performanceId);
+        putIfPresent(payload, "deeplink", deeplink);
+        putIfPresent(payload, "targetRoute", deeplink);
+        return payload;
+    }
+
+    private static void putIfPresent(Map<String, String> payload, String key, Object value) {
+        if (value == null) {
+            return;
+        }
+        String stringValue = value.toString();
+        if (!stringValue.isBlank()) {
+            payload.put(key, stringValue);
+        }
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/fcm/service/FirebaseFcmService.java
+++ b/src/main/java/me/sogom/bridge/domain/fcm/service/FirebaseFcmService.java
@@ -55,13 +55,11 @@ public class FirebaseFcmService implements FcmService {
             if (token == null || token.isBlank()) {
                 return;
             }
-            Message firebaseMessage = Message.builder()
-                    .setToken(token)
-                    .putData("title", message.title())
-                    .putData("body", message.body())
-                    .putData("type", message.type())
-                    .putData("targetId", String.valueOf(message.targetId()))
-                    .build();
+            Message.Builder firebaseMessageBuilder = Message.builder()
+                    .setToken(token);
+            applyVisibleNotification(firebaseMessageBuilder, message);
+            message.dataPayload().forEach(firebaseMessageBuilder::putData);
+            Message firebaseMessage = firebaseMessageBuilder.build();
             FirebaseMessaging.getInstance().send(firebaseMessage);
             log.info("Firebase Push 전송 완료");
         } catch (Exception e) {
@@ -111,5 +109,30 @@ public class FirebaseFcmService implements FcmService {
         }
 
         return null;
+    }
+
+    private void applyVisibleNotification(
+            Message.Builder firebaseMessageBuilder,
+            FcmMessageDTO message
+    ) {
+
+        if (isBlank(message.title()) && isBlank(message.body())) {
+            return;
+        }
+
+        com.google.firebase.messaging.Notification.Builder notificationBuilder =
+                com.google.firebase.messaging.Notification.builder();
+        if (!isBlank(message.title())) {
+            notificationBuilder.setTitle(message.title());
+        }
+        if (!isBlank(message.body())) {
+            notificationBuilder.setBody(message.body());
+        }
+
+        firebaseMessageBuilder.setNotification(notificationBuilder.build());
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/src/main/java/me/sogom/bridge/domain/fcm/service/MockFcmService.java
+++ b/src/main/java/me/sogom/bridge/domain/fcm/service/MockFcmService.java
@@ -38,6 +38,10 @@ public class MockFcmService implements FcmService {
         log.info("Body : {}", message.body());
         log.info("Type : {}", message.type());
         log.info("TargetId : {}", message.targetId());
+        log.info("ChildId : {}", message.childId());
+        log.info("MissionId : {}", message.missionId());
+        log.info("PerformanceId : {}", message.performanceId());
+        log.info("Deeplink : {}", message.deeplink());
     }
 
     // Silent Push Mock 전송

--- a/src/main/java/me/sogom/bridge/domain/member/controller/ParentController.java
+++ b/src/main/java/me/sogom/bridge/domain/member/controller/ParentController.java
@@ -7,11 +7,14 @@ import me.sogom.bridge.domain.member.dto.req.MemberReqDTO;
 import me.sogom.bridge.domain.member.dto.res.MemberResDTO;
 import me.sogom.bridge.domain.member.service.ParentService;
 import me.sogom.bridge.domain.policy.dto.PolicyReqDTO;
+import me.sogom.bridge.domain.schedule.dto.TimeSummaryResponse;
 import me.sogom.bridge.global.apiPayload.ApiResponse;
 import me.sogom.bridge.global.security.entity.AuthMember;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -31,7 +34,7 @@ public class ParentController {
     public ApiResponse<MemberResDTO.ChildrenInfoResponse> registerChild(
             @AuthenticationPrincipal AuthMember authMember,
             @RequestBody @Valid MemberReqDTO.RegisterChildRequest request) {
-        Long parentId = authMember.getMember().getId();
+        Long parentId = authMember.asParent().getId();
         MemberResDTO.ChildrenInfoResponse response = parentService.registerChild(parentId, request);
         return ApiResponse.onSuccess(MemberSuccessCode.CHILDREN_REGISTER_SUCCESS, response);
     }
@@ -44,7 +47,7 @@ public class ParentController {
     @GetMapping("/children")
     public ApiResponse<List<MemberResDTO.ChildrenInfoResponse>> getChildrenList(
             @AuthenticationPrincipal AuthMember authMember) {
-        Long parentId = authMember.getMember().getId();
+        Long parentId = authMember.asParent().getId();
         List<MemberResDTO.ChildrenInfoResponse> childrenList = parentService.getChildrenList(parentId);
         return ApiResponse.onSuccess(MemberSuccessCode.CHILDREN_LIST_SUCCESS, childrenList);
     }
@@ -59,9 +62,20 @@ public class ParentController {
     public ApiResponse<Void> setTimePolicy(
             @AuthenticationPrincipal AuthMember authMember,
             @RequestBody @Valid PolicyReqDTO.SetTimePolicyRequest request) {
-        Long parentId = authMember.getMember().getId();
+        Long parentId = authMember.asParent().getId();
         parentService.setTimePolicy(parentId, request);
         return ApiResponse.onSuccess(MemberSuccessCode.TIME_POLICY_SET_SUCCESS, null);
     }
-}
 
+    @GetMapping("/children/{childId}/time-summary")
+    public ApiResponse<TimeSummaryResponse> getChildTimeSummary(
+            @AuthenticationPrincipal AuthMember authMember,
+            @PathVariable Long childId,
+            @RequestParam(required = false)
+            @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+        Long parentId = authMember.asParent().getId();
+        LocalDate targetDate = date != null ? date : LocalDate.now();
+        TimeSummaryResponse response = parentService.getChildTimeSummary(parentId, childId, targetDate);
+        return ApiResponse.onSuccess(MemberSuccessCode.CHILDREN_LIST_SUCCESS, response);
+    }
+}

--- a/src/main/java/me/sogom/bridge/domain/member/dto/req/MemberReqDTO.java
+++ b/src/main/java/me/sogom/bridge/domain/member/dto/req/MemberReqDTO.java
@@ -57,6 +57,10 @@ public class MemberReqDTO {
             String childrenName,
 
             @Nullable
+            @Pattern(
+                    regexp = "^\\d{4}$",
+                    message = "자녀 출생연도는 4자리 연도여야 합니다."
+            )
             String childrenBirth,
 
             @NotBlank(message = "자녀 코드를 입력해 주세요.")

--- a/src/main/java/me/sogom/bridge/domain/member/service/ParentService.java
+++ b/src/main/java/me/sogom/bridge/domain/member/service/ParentService.java
@@ -120,7 +120,12 @@ public class ParentService {
         );
         if (existingPolicy.isPresent()) {
             TimePolicy policy = existingPolicy.get();
-            if (policy.getBaseTime() != request.baseTime()) {
+            boolean childPlanExists = scheduleService.hasChildPlan(request.childId(), request.yearMonth());
+            int currentPolicyMinutes = childPlanExists
+                    ? scheduleService.findMonthlyBudgetTotal(request.childId(), request.yearMonth())
+                            .orElse(policy.getBaseTime())
+                    : policy.getBaseTime();
+            if (currentPolicyMinutes != request.baseTime()) {
                 policy.updateBaseTime(request.baseTime());
                 scheduleService.clearChildPlan(request.childId(), request.yearMonth());
             }
@@ -192,13 +197,15 @@ public class ParentService {
                     .build();
         }
 
+        int basePolicyMinutes = scheduleService.findMonthlyBudgetTotal(childId, yearMonth)
+                .orElse(activePolicy.getBaseTime());
         Optional<DailyScheduleResponse> dailySchedule = scheduleService.findDailySchedulePreview(childId, date);
         return TimeSummaryResponse.builder()
                 .parentPolicyExists(true)
                 .childPlanExists(true)
                 .todayScheduleStatus(dailySchedule.isPresent() ? "available" : "templateMissing")
                 .yearMonth(yearMonth)
-                .basePolicyMinutes(activePolicy.getBaseTime())
+                .basePolicyMinutes(basePolicyMinutes)
                 .todaySchedule(dailySchedule.orElse(null))
                 .rewardPoolMinutes(activePolicy.getAccumulatedRewardTime())
                 .build();

--- a/src/main/java/me/sogom/bridge/domain/member/service/ParentService.java
+++ b/src/main/java/me/sogom/bridge/domain/member/service/ParentService.java
@@ -11,15 +11,22 @@ import me.sogom.bridge.domain.member.entity.MemberStatus;
 import me.sogom.bridge.domain.member.entity.Parent;
 import me.sogom.bridge.domain.member.repository.ChildrenRepository;
 import me.sogom.bridge.domain.member.repository.ParentRepository;
+import me.sogom.bridge.domain.notification.entity.NotificationType;
+import me.sogom.bridge.domain.notification.service.NotificationService;
 import me.sogom.bridge.domain.policy.dto.PolicyReqDTO;
 import me.sogom.bridge.domain.policy.entity.TimePolicy;
 import me.sogom.bridge.domain.policy.repository.TimePolicyRepository;
+import me.sogom.bridge.domain.schedule.dto.DailyScheduleResponse;
+import me.sogom.bridge.domain.schedule.dto.TimeSummaryResponse;
+import me.sogom.bridge.domain.schedule.service.ScheduleService;
 import me.sogom.bridge.global.security.entity.MemberRole;
 import me.sogom.bridge.global.storage.PhotoUrlResolver;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -29,9 +36,11 @@ public class ParentService {
     private final ParentRepository parentRepository;
     private final ChildrenRepository childrenRepository;
     private final TimePolicyRepository timePolicyRepository;
+    private final ScheduleService scheduleService;
 
     // FCM 서비스
     private final FcmService fcmService;
+    private final NotificationService notificationService;
 
     // 프로필 이미지 key → presigned URL 변환
     private final PhotoUrlResolver photoUrlResolver;
@@ -103,28 +112,28 @@ public class ParentService {
                 .orElseThrow(() -> new MemberException(MemberErrorCode.CHILDREN_NOT_FOUND));
 
         // 자녀가 해당 부모와 연결되어 있는지 확인
-        if (!child.getParent().getId().equals(parentId)) {
-            throw new MemberException(MemberErrorCode.CHILDREN_PARENT_MISMATCH);
+        validateParentChild(parentId, child);
+
+        Optional<TimePolicy> existingPolicy = timePolicyRepository.findByChildIdAndYearMonth(
+                request.childId(),
+                request.yearMonth()
+        );
+        if (existingPolicy.isPresent()) {
+            TimePolicy policy = existingPolicy.get();
+            if (policy.getBaseTime() != request.baseTime()) {
+                policy.updateBaseTime(request.baseTime());
+                scheduleService.clearChildPlan(request.childId(), request.yearMonth());
+            }
+        } else {
+            TimePolicy newPolicy = TimePolicy.builder()
+                    .parent(parent)
+                    .child(child)
+                    .yearMonth(request.yearMonth())
+                    .baseTime(request.baseTime())
+                    .accumulatedRewardTime(0)
+                    .build();
+            timePolicyRepository.save(newPolicy);
         }
-
-        timePolicyRepository.findByChildIdAndYearMonth(request.childId(), request.yearMonth())
-                .ifPresentOrElse(
-
-                        // 이미 존재하는 경우 기본 시간 수정
-                        policy -> policy.updateBaseTime(request.baseTime()),
-
-                        // 존재하지 않는 경우 새 정책 생성
-                        () -> {
-                            TimePolicy newPolicy = TimePolicy.builder()
-                                    .parent(parent)
-                                    .child(child)
-                                    .yearMonth(request.yearMonth())
-                                    .baseTime(request.baseTime())
-                                    .accumulatedRewardTime(0)
-                                    .build();
-                            timePolicyRepository.save(newPolicy);
-                        }
-                );
 
         // 자녀 앱 정책 갱신 Silent Push 전송
         fcmService.sendSilentPush(
@@ -132,5 +141,72 @@ public class ParentService {
                 MemberRole.CHILDREN,
                 "TIME_POLICY_UPDATED"
         );
+
+        notificationService.createNotification(
+                child.getId(),
+                MemberRole.CHILDREN,
+                "시간 설정 완료",
+                "부모님이 이번 달 사용 시간을 설정했습니다.",
+                NotificationType.GENERAL,
+                child.getId(),
+                null,
+                null,
+                "/child-home/time-setup"
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public TimeSummaryResponse getChildTimeSummary(Long parentId, Long childId, LocalDate date) {
+        parentRepository.findById(parentId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        Children child = childrenRepository.findById(childId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.CHILDREN_NOT_FOUND));
+        validateParentChild(parentId, child);
+
+        String yearMonth = scheduleService.yearMonthOf(date);
+        Optional<TimePolicy> policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth);
+        if (policy.isEmpty()) {
+            return TimeSummaryResponse.builder()
+                    .parentPolicyExists(false)
+                    .childPlanExists(false)
+                    .todayScheduleStatus("noParentPolicy")
+                    .yearMonth(yearMonth)
+                    .basePolicyMinutes(0)
+                    .todaySchedule(null)
+                    .rewardPoolMinutes(0)
+                    .build();
+        }
+
+        TimePolicy activePolicy = policy.get();
+        boolean childPlanExists = scheduleService.hasChildPlan(childId, yearMonth);
+        if (!childPlanExists) {
+            return TimeSummaryResponse.builder()
+                    .parentPolicyExists(true)
+                    .childPlanExists(false)
+                    .todayScheduleStatus("waitingChildPlan")
+                    .yearMonth(yearMonth)
+                    .basePolicyMinutes(activePolicy.getBaseTime())
+                    .todaySchedule(null)
+                    .rewardPoolMinutes(activePolicy.getAccumulatedRewardTime())
+                    .build();
+        }
+
+        Optional<DailyScheduleResponse> dailySchedule = scheduleService.findDailySchedulePreview(childId, date);
+        return TimeSummaryResponse.builder()
+                .parentPolicyExists(true)
+                .childPlanExists(true)
+                .todayScheduleStatus(dailySchedule.isPresent() ? "available" : "templateMissing")
+                .yearMonth(yearMonth)
+                .basePolicyMinutes(activePolicy.getBaseTime())
+                .todaySchedule(dailySchedule.orElse(null))
+                .rewardPoolMinutes(activePolicy.getAccumulatedRewardTime())
+                .build();
+    }
+
+    private void validateParentChild(Long parentId, Children child) {
+        if (child.getParent() == null || !child.getParent().getId().equals(parentId)) {
+            throw new MemberException(MemberErrorCode.CHILDREN_PARENT_MISMATCH);
+        }
     }
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/controller/MissionController.java
@@ -78,9 +78,23 @@ public class MissionController {
     //미션 상세정보 조회 API
     @GetMapping("/{missionId}")
     public ApiResponse<MissionResDTO.MissionResponse> getMissionDetail(
-            @PathVariable("missionId") Long missionId) {
+            @PathVariable("missionId") Long missionId,
+            @AuthenticationPrincipal AuthMember authMember) {
 
-        MissionResDTO.MissionResponse response = missionService.getMissionDetail(missionId);
+        Long viewerId;
+        if (authMember.getRole() == MemberRole.PARENT) {
+            viewerId = authMember.asParent().getId();
+        } else if (authMember.getRole() == MemberRole.CHILDREN) {
+            viewerId = authMember.asChildren().getId();
+        } else {
+            throw new ProjectException(GeneralErrorCode.FORBIDDEN);
+        }
+
+        MissionResDTO.MissionResponse response = missionService.getMissionDetail(
+                missionId,
+                authMember.getRole(),
+                viewerId
+        );
         return ApiResponse.onSuccess(MissionSuccessCode.MISSION_LIST_SUCCESS, response);
     }
 
@@ -103,8 +117,16 @@ public class MissionController {
             @PathVariable("missionId") Long missionId,
             @AuthenticationPrincipal AuthMember authMember) {
 
-        Long parentId = authMember.asParent().getId();
-        MissionPerformanceResDTO.MissionPerformanceResponse response = performanceService.getMissionPerformance(missionId, parentId);
+        MissionPerformanceResDTO.MissionPerformanceResponse response;
+        if (authMember.getRole() == MemberRole.PARENT) {
+            Long parentId = authMember.asParent().getId();
+            response = performanceService.getMissionPerformance(missionId, parentId);
+        } else if (authMember.getRole() == MemberRole.CHILDREN) {
+            Long childId = authMember.asChildren().getId();
+            response = performanceService.getChildMissionPerformance(missionId, childId);
+        } else {
+            throw new ProjectException(GeneralErrorCode.FORBIDDEN);
+        }
         return ApiResponse.onSuccess(MissionSuccessCode.MISSION_PERFORMANCE_RETRIEVE_SUCCESS, response);
     }
 

--- a/src/main/java/me/sogom/bridge/domain/mission/dto/AiVerificationResponse.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/dto/AiVerificationResponse.java
@@ -1,7 +1,11 @@
 package me.sogom.bridge.domain.mission.dto;
 
+import me.sogom.bridge.domain.mission.entity.MissionStatus;
+
 // AI가 JSON 형태로 뱉어줄 응답 구조
 public record AiVerificationResponse(
         boolean isAccepted,
-        String reason // 통과/실패 이유 (자녀에게 피드백용)
+        String reason, // 통과/실패 이유 (자녀에게 피드백용)
+        MissionStatus status,
+        Long performanceId
 ) {}

--- a/src/main/java/me/sogom/bridge/domain/mission/exception/MissionErrorCode.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/exception/MissionErrorCode.java
@@ -13,7 +13,9 @@ public enum MissionErrorCode implements BaseErrorCode {
     AI_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MISSION500", "AI 판독 결과를 처리하는 중 오류가 발생했습니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "MISSION403", "해당 미션에 대한 수행 권한이 없습니다."), //권한 검증 실패 시 사용
     CHILD_PARENT_MISMATCH(HttpStatus.FORBIDDEN, "MISSION403_CHILD", "해당 자녀에게 미션을 부여할 권한이 없습니다."),
-    MISSION_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "MISSION400", "이미 완료된 미션입니다.");
+    MISSION_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "MISSION_ALREADY_COMPLETED", "이미 완료된 미션입니다."),
+    MISSION_ALREADY_SUBMITTED(HttpStatus.BAD_REQUEST, "MISSION_ALREADY_SUBMITTED", "이미 확인 대기 중인 미션입니다."),
+    INVALID_MISSION_STATE(HttpStatus.BAD_REQUEST, "INVALID_MISSION_STATE", "대기 상태인 부모 확인 미션만 승인/반려할 수 있습니다.");
     // 필요할 때마다 여기에 추가 예정
 
     private final HttpStatus status;

--- a/src/main/java/me/sogom/bridge/domain/mission/repository/MissionPerformanceRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/repository/MissionPerformanceRepository.java
@@ -1,6 +1,7 @@
 package me.sogom.bridge.domain.mission.repository;
 
 import me.sogom.bridge.domain.mission.entity.MissionPerformance;
+import me.sogom.bridge.domain.mission.entity.MissionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,4 +10,6 @@ import java.util.Optional;
 public interface MissionPerformanceRepository extends JpaRepository<MissionPerformance, Long> {
     //미션 ID로 조회하여 가장 최근에 등록된 내역 1건만 가져오는 메서드
     Optional<MissionPerformance> findTopByMissionIdOrderByIdDesc(Long missionId);
+
+    boolean existsByMissionIdAndStatus(Long missionId, MissionStatus status);
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionPerformanceService.java
@@ -57,14 +57,18 @@ public class MissionPerformanceService {
             throw new MissionException(MissionErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        //해당 미션의 가장 최근 수행 내역을 확인합니다.
-        performanceRepository.findTopByMissionIdOrderByIdDesc(missionId)
-                .ifPresent(lastPerformance -> {
-                    // 이미 부모나 AI가 승인(ACCEPTED)한 미션이라면 더 이상 진행하지 못하게 차단!
-                    if (lastPerformance.getStatus() == MissionStatus.ACCEPTED) {
-                        throw new MissionException(MissionErrorCode.MISSION_ALREADY_COMPLETED);
-                    }
-                });
+        assertMissionIsNotCompleted(missionId);
+        assertMissionIsNotPendingReview(missionId);
+
+        // 미션 설정 정보 조회
+        MissionSetting setting = missionSettingRepository.findByMissionId(missionId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
+
+        // 인증 사진을 S3에 업로드하고 key를 performance에 저장 (모든 인증 방식 공통)
+        String proofImageKey = storageService.upload(
+                image,
+                PhotoCategory.MISSION.keyPrefix(MemberRole.CHILDREN.name(), childId)
+        );
 
         // 2. [PENDING 먼저 저장] AI를 호출하기 전에 우선 수행 내역을 'PENDING' 상태로 DB에 저장합니다.
         MissionPerformance performance = MissionPerformance.builder()
@@ -73,18 +77,9 @@ public class MissionPerformanceService {
                 .status(MissionStatus.PENDING) // 무조건 대기 상태로 시작!
                 .reason("AI가 사진을 분석하고 있습니다.")
                 .build();
+        performance.updateProofImageKey(proofImageKey);
         performanceRepository.save(performance);
 
-        // 인증 사진을 S3에 업로드하고 key를 performance에 저장 (모든 인증 방식 공통)
-        String proofImageKey = storageService.upload(
-                image,
-                PhotoCategory.MISSION.keyPrefix(MemberRole.CHILDREN.name(), childId)
-        );
-        performance.updateProofImageKey(proofImageKey);
-
-        // 미션 설정 정보 조회
-        MissionSetting setting = missionSettingRepository.findByMissionId(missionId)
-                .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
         MissionCategory category = setting.getCategory();   //카테고리를 미션id로 받아옴
         String prompt = setting.getDescription();   //부모가 미션 세팅 시 미션 설명 적은걸 가져옴
 
@@ -107,12 +102,18 @@ public class MissionPerformanceService {
                     MemberRole.PARENT,
                     "미션 확인 요청",
                     child.getName() + "님이 미션 확인을 요청했습니다.",
-                    NotificationType.GENERAL
+                    NotificationType.MISSION_REQUESTED,
+                    child.getId(),
+                    mission.getId(),
+                    performance.getId(),
+                    "/today-mission?childrenId=" + child.getId()
             );
 
             return new AiVerificationResponse(
                     false,
-                    "부모님 확인 대기중입니다."
+                    "부모님 확인 대기중입니다.",
+                    performance.getStatus(),
+                    performance.getId()
             );
         }
 
@@ -149,12 +150,18 @@ public class MissionPerformanceService {
                     MemberRole.PARENT,
                     "미션 완료",
                     child.getName() + "님이 미션을 완료했습니다.",
-                    NotificationType.GENERAL
+                    NotificationType.MISSION_APPROVED,
+                    child.getId(),
+                    mission.getId(),
+                    performance.getId(),
+                    "/today-mission?childrenId=" + child.getId()
             );
 
             return new AiVerificationResponse(
                     true,
-                    "미션 완료로 보상 시간이 지급되었습니다."
+                    "미션 완료로 보상 시간이 지급되었습니다.",
+                    performance.getStatus(),
+                    performance.getId()
             );
         }
 
@@ -196,23 +203,73 @@ public class MissionPerformanceService {
                         MemberRole.PARENT,
                         "AI 미션 인증 완료",
                         child.getName() + "님의 미션이 AI 인증되었습니다.",
-                        NotificationType.GENERAL
+                        NotificationType.MISSION_APPROVED,
+                        child.getId(),
+                        mission.getId(),
+                        performance.getId(),
+                        "/today-mission?childrenId=" + child.getId()
+                );
+
+                notificationService.createNotification(
+                        child.getId(),
+                        MemberRole.CHILDREN,
+                        "미션 완료",
+                        "AI가 미션 수행을 확인했습니다.",
+                        NotificationType.MISSION_APPROVED,
+                        child.getId(),
+                        mission.getId(),
+                        performance.getId(),
+                        "/child-home/mission/" + mission.getId()
+                );
+            } else {
+                notificationService.createNotification(
+                        child.getId(),
+                        MemberRole.CHILDREN,
+                        "미션 반려",
+                        "AI가 미션 수행을 반려했습니다.",
+                        NotificationType.MISSION_REJECTED,
+                        child.getId(),
+                        mission.getId(),
+                        performance.getId(),
+                        "/child-home/mission/" + mission.getId()
                 );
             }
 
         } catch (Exception e) {
             e.printStackTrace();
-            // [AI 예외 처리] 구글 AI 서버 오류나 네트워크 장애 발생 시 Failsafe 우회
-            // DB에는 2번 단계에서 넣은 PENDING 데이터가 그대로 안전하게 유지
-            aiResponse = new AiVerificationResponse(false, "AI 서버 일시 오류로 인해 부모님 확인 대기 상태로 전환되었습니다.");
-            performance.updateStatusAndReason(MissionStatus.PENDING, aiResponse.reason());
+            // [AI 예외 처리] AI 미션은 부모 승인 API 대상이 아니므로 PENDING으로
+            // 남기면 앱에서 처리할 수 없는 대기 상태가 된다. 반려로 정리해
+            // 자녀가 다시 제출할 수 있게 한다.
+            aiResponse = new AiVerificationResponse(
+                    false,
+                    "AI 서버 일시 오류로 인해 다시 제출해 주세요.",
+                    MissionStatus.REJECTED,
+                    performance.getId()
+            );
+            performance.updateStatusAndReason(MissionStatus.REJECTED, aiResponse.reason());
+            notificationService.createNotification(
+                    child.getId(),
+                    MemberRole.CHILDREN,
+                    "미션 반려",
+                    "AI 확인에 실패해 다시 수행이 필요합니다.",
+                    NotificationType.MISSION_REJECTED,
+                    child.getId(),
+                    mission.getId(),
+                    performance.getId(),
+                    "/child-home/mission/" + mission.getId()
+            );
         }
 
         //최종적으로 DB에 영속화 (Save)
         performanceRepository.save(performance);
 
         //프론트엔드에게 돌려줄 AI 응답 반환
-        return aiResponse;
+        return new AiVerificationResponse(
+                aiResponse.isAccepted(),
+                aiResponse.reason(),
+                performance.getStatus(),
+                performance.getId()
+        );
     }
 
     @Transactional(readOnly = true)
@@ -223,6 +280,22 @@ public class MissionPerformanceService {
 
         // 부모 권한 검증
         if (!mission.getParent().getId().equals(parentId)) {
+            throw new MissionException(MissionErrorCode.UNAUTHORIZED_ACCESS);
+        }
+
+        MissionPerformance performance = performanceRepository.findTopByMissionIdOrderByIdDesc(missionId)
+                .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
+
+        return MissionPerformanceResDTO.MissionPerformanceResponse.of(performance, photoUrlResolver);
+    }
+
+    @Transactional(readOnly = true)
+    public MissionPerformanceResDTO.MissionPerformanceResponse getChildMissionPerformance(Long missionId, Long childId) {
+
+        Mission mission = missionRepository.findById(missionId)
+                .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
+
+        if (!mission.getChild().getId().equals(childId)) {
             throw new MissionException(MissionErrorCode.UNAUTHORIZED_ACCESS);
         }
 
@@ -245,19 +318,17 @@ public class MissionPerformanceService {
             throw new MissionException(MissionErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        // 대기 상태인 미션만 승인 가능
-        if (performance.getStatus() != MissionStatus.PENDING) {
-            throw new IllegalStateException("대기 상태인 미션만 승인할 수 있습니다.");
-        }
+        // 해당 미션의 설정 정보 조회
+        MissionSetting setting = missionSettingRepository.findByMissionId(mission.getId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
+
+        validateParentReviewable(performance, setting);
+        assertMissionHasNoAcceptedPerformance(mission.getId(), performance);
 
         performance.updateStatusAndReason(
                 MissionStatus.ACCEPTED,
                 "부모님이 미션을 승인했습니다."
         );
-
-        // 해당 미션의 설정 정보 조회
-        MissionSetting setting = missionSettingRepository.findByMissionId(mission.getId())
-                .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
 
         int rewardTime = setting.getReward();
 
@@ -286,7 +357,11 @@ public class MissionPerformanceService {
                 MemberRole.CHILDREN,
                 "미션 승인 완료",
                 "부모님이 미션을 승인했습니다.",
-                NotificationType.MISSION_APPROVED
+                NotificationType.MISSION_APPROVED,
+                performance.getChild().getId(),
+                mission.getId(),
+                performance.getId(),
+                "/child-home/mission/" + mission.getId()
         );
     }
 
@@ -303,10 +378,10 @@ public class MissionPerformanceService {
             throw new MissionException(MissionErrorCode.UNAUTHORIZED_ACCESS);
         }
 
-        // 대기 상태인 미션만 거절 가능
-        if (performance.getStatus() != MissionStatus.PENDING) {
-            throw new IllegalStateException("대기 상태인 미션만 거절할 수 있습니다.");
-        }
+        MissionSetting setting = missionSettingRepository.findByMissionId(mission.getId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 미션의 설정 정보를 찾을 수 없습니다."));
+
+        validateParentReviewable(performance, setting);
 
         performance.updateStatusAndReason(
                 MissionStatus.REJECTED,
@@ -321,7 +396,43 @@ public class MissionPerformanceService {
                 MemberRole.CHILDREN,
                 "미션 거절",
                 "부모님이 미션을 거절했습니다.",
-                NotificationType.MISSION_REJECTED
+                NotificationType.MISSION_REJECTED,
+                performance.getChild().getId(),
+                mission.getId(),
+                performance.getId(),
+                "/child-home/mission/" + mission.getId()
         );
+    }
+
+    private void validateParentReviewable(MissionPerformance performance, MissionSetting setting) {
+        if (performance.getStatus() != MissionStatus.PENDING ||
+                setting.getVerificationType() != VerificationType.PARENT) {
+            throw new MissionException(MissionErrorCode.INVALID_MISSION_STATE);
+        }
+    }
+
+    private void assertMissionIsNotCompleted(Long missionId) {
+        if (performanceRepository.existsByMissionIdAndStatus(missionId, MissionStatus.ACCEPTED)) {
+            throw new MissionException(MissionErrorCode.MISSION_ALREADY_COMPLETED);
+        }
+    }
+
+    private void assertMissionIsNotPendingReview(Long missionId) {
+        performanceRepository.findTopByMissionIdOrderByIdDesc(missionId)
+                .ifPresent(lastPerformance -> {
+                    if (lastPerformance.getStatus() == MissionStatus.PENDING) {
+                        throw new MissionException(MissionErrorCode.MISSION_ALREADY_SUBMITTED);
+                    }
+                });
+    }
+
+    private void assertMissionHasNoAcceptedPerformance(
+            Long missionId,
+            MissionPerformance currentPerformance
+    ) {
+        if (currentPerformance.getStatus() == MissionStatus.ACCEPTED) {
+            return;
+        }
+        assertMissionIsNotCompleted(missionId);
     }
 }

--- a/src/main/java/me/sogom/bridge/domain/mission/service/MissionService.java
+++ b/src/main/java/me/sogom/bridge/domain/mission/service/MissionService.java
@@ -74,7 +74,11 @@ public class MissionService {
                 MemberRole.CHILDREN,
                 "새 미션이 생성되었습니다.",
                 mission.getTitle(),
-                NotificationType.MISSION_CREATED
+                NotificationType.MISSION_CREATED,
+                child.getId(),
+                mission.getId(),
+                null,
+                "/child-home/mission/" + mission.getId()
         );
 
         return MissionResDTO.MissionResponse.of(mission, setting);
@@ -96,9 +100,15 @@ public class MissionService {
     }
 
     @Transactional(readOnly = true)
-    public MissionResDTO.MissionResponse getMissionDetail(Long missionId) {
+    public MissionResDTO.MissionResponse getMissionDetail(
+            Long missionId,
+            MemberRole viewerRole,
+            Long viewerId
+    ) {
         Mission mission = missionRepository.findById(missionId)
                 .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
+
+        validateMissionViewer(mission, viewerRole, viewerId);
 
         MissionSetting setting = missionSettingRepository.findByMissionId(missionId)
                 .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
@@ -113,5 +123,19 @@ public class MissionService {
                 .orElseThrow(() -> new MemberException(MemberErrorCode.CHILDREN_NOT_FOUND));
 
         return missionSettingRepository.findMissionSummariesByChildId(child.getId());
+    }
+
+    private void validateMissionViewer(Mission mission, MemberRole viewerRole, Long viewerId) {
+        if (viewerRole == MemberRole.PARENT &&
+                mission.getParent() != null &&
+                mission.getParent().getId().equals(viewerId)) {
+            return;
+        }
+        if (viewerRole == MemberRole.CHILDREN &&
+                mission.getChild() != null &&
+                mission.getChild().getId().equals(viewerId)) {
+            return;
+        }
+        throw new MissionException(MissionErrorCode.UNAUTHORIZED_ACCESS);
     }
 }

--- a/src/main/java/me/sogom/bridge/domain/notification/controller/NotificationController.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/controller/NotificationController.java
@@ -31,7 +31,11 @@ public class NotificationController {
                 request.memberRole(),
                 request.title(),
                 request.content(),
-                request.notificationType()
+                request.notificationType(),
+                request.childId(),
+                request.missionId(),
+                request.performanceId(),
+                request.targetRoute()
         );
 
         return ApiResponse.onSuccess(

--- a/src/main/java/me/sogom/bridge/domain/notification/dto/req/NotificationReqDTO.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/dto/req/NotificationReqDTO.java
@@ -22,7 +22,15 @@ public class NotificationReqDTO {
             String content,
 
             @NotNull
-            NotificationType notificationType
+            NotificationType notificationType,
+
+            Long childId,
+
+            Long missionId,
+
+            Long performanceId,
+
+            String targetRoute
 
     ) {
     }

--- a/src/main/java/me/sogom/bridge/domain/notification/dto/res/NotificationResDTO.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/dto/res/NotificationResDTO.java
@@ -5,6 +5,8 @@ import me.sogom.bridge.domain.notification.entity.Notification;
 import me.sogom.bridge.domain.notification.entity.NotificationType;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 public class NotificationResDTO {
 
@@ -21,7 +23,17 @@ public class NotificationResDTO {
 
             NotificationType notificationType,
 
-            LocalDateTime createdAt
+            LocalDateTime createdAt,
+
+            Long childId,
+
+            Long missionId,
+
+            Long performanceId,
+
+            String deeplink,
+
+            Map<String, Object> payload
 
     ) {
 
@@ -35,7 +47,38 @@ public class NotificationResDTO {
                     .isRead(notification.getIsRead())
                     .notificationType(notification.getNotificationType())
                     .createdAt(notification.getCreatedAt())
+                    .childId(notification.getChildId())
+                    .missionId(notification.getMissionId())
+                    .performanceId(notification.getPerformanceId())
+                    .deeplink(notification.getTargetRoute())
+                    .payload(payloadOf(notification))
                     .build();
+        }
+
+        private static Map<String, Object> payloadOf(Notification notification) {
+            Map<String, Object> payload = new LinkedHashMap<>();
+            if (notification.getId() != null) {
+                payload.put("notificationId", notification.getId().toString());
+            }
+            if (notification.getNotificationType() != null) {
+                payload.put("notificationType", notification.getNotificationType().name());
+                payload.put("type", notification.getNotificationType().name());
+            }
+            if (notification.getChildId() != null) {
+                payload.put("childId", notification.getChildId().toString());
+                payload.put("childrenId", notification.getChildId().toString());
+            }
+            if (notification.getMissionId() != null) {
+                payload.put("missionId", notification.getMissionId().toString());
+            }
+            if (notification.getPerformanceId() != null) {
+                payload.put("performanceId", notification.getPerformanceId().toString());
+            }
+            if (notification.getTargetRoute() != null && !notification.getTargetRoute().isBlank()) {
+                payload.put("targetRoute", notification.getTargetRoute());
+                payload.put("deeplink", notification.getTargetRoute());
+            }
+            return payload;
         }
     }
 }

--- a/src/main/java/me/sogom/bridge/domain/notification/entity/Notification.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/entity/Notification.java
@@ -44,6 +44,14 @@ public class Notification extends BaseEntity {
     @Column(nullable = false)
     private NotificationType notificationType;
 
+    private Long childId;
+
+    private Long missionId;
+
+    private Long performanceId;
+
+    private String targetRoute;
+
     @Builder
     public Notification(
             Long memberId,
@@ -51,7 +59,11 @@ public class Notification extends BaseEntity {
             String title,
             String content,
             Boolean isRead,
-            NotificationType notificationType
+            NotificationType notificationType,
+            Long childId,
+            Long missionId,
+            Long performanceId,
+            String targetRoute
     ) {
         this.memberId = memberId;
         this.memberRole = memberRole;
@@ -59,6 +71,10 @@ public class Notification extends BaseEntity {
         this.content = content;
         this.isRead = isRead;
         this.notificationType = notificationType;
+        this.childId = childId;
+        this.missionId = missionId;
+        this.performanceId = performanceId;
+        this.targetRoute = targetRoute;
     }
 
     // 알림 읽음 처리

--- a/src/main/java/me/sogom/bridge/domain/notification/entity/NotificationType.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/entity/NotificationType.java
@@ -3,6 +3,7 @@ package me.sogom.bridge.domain.notification.entity;
 public enum NotificationType {
 
     MISSION_CREATED,
+    MISSION_REQUESTED,
     MISSION_APPROVED,
     MISSION_REJECTED,
     GENERAL

--- a/src/main/java/me/sogom/bridge/domain/notification/service/NotificationService.java
+++ b/src/main/java/me/sogom/bridge/domain/notification/service/NotificationService.java
@@ -33,6 +33,31 @@ public class NotificationService {
             String content,
             NotificationType notificationType
     ) {
+        createNotification(
+                memberId,
+                memberRole,
+                title,
+                content,
+                notificationType,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    @Transactional
+    public void createNotification(
+            Long memberId,
+            MemberRole memberRole,
+            String title,
+            String content,
+            NotificationType notificationType,
+            Long childId,
+            Long missionId,
+            Long performanceId,
+            String targetRoute
+    ) {
 
         Notification notification = Notification.builder()
                 .memberId(memberId)
@@ -41,6 +66,10 @@ public class NotificationService {
                 .content(content)
                 .isRead(false)
                 .notificationType(notificationType)
+                .childId(childId)
+                .missionId(missionId)
+                .performanceId(performanceId)
+                .targetRoute(targetRoute)
                 .build();
 
         // 알림 저장
@@ -54,6 +83,10 @@ public class NotificationService {
                     .body(content)
                     .type(notificationType.name())
                     .targetId(notification.getId())
+                    .childId(childId)
+                    .missionId(missionId)
+                    .performanceId(performanceId)
+                    .deeplink(targetRoute)
                     .build();
 
             fcmService.sendPush(

--- a/src/main/java/me/sogom/bridge/domain/policy/controller/ChildPolicyController.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/controller/ChildPolicyController.java
@@ -1,10 +1,15 @@
 package me.sogom.bridge.domain.policy.controller;
 
 import lombok.RequiredArgsConstructor;
+import me.sogom.bridge.domain.member.entity.Children;
 import me.sogom.bridge.domain.policy.dto.PolicyResponse;
 import me.sogom.bridge.domain.policy.service.ChildPolicyService;
 import me.sogom.bridge.global.apiPayload.ApiResponse;
 import me.sogom.bridge.global.apiPayload.code.GeneralSuccessCode;
+import me.sogom.bridge.global.apiPayload.code.GeneralErrorCode;
+import me.sogom.bridge.global.apiPayload.exception.ProjectException;
+import me.sogom.bridge.global.security.entity.AuthMember;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,7 +24,14 @@ public class ChildPolicyController {
      자녀 앱 구동 시 필요한 시간 제한 및 앱 차단 리스트를 반환
      */
     @GetMapping("/{childId}/policies")
-    public ApiResponse<PolicyResponse> getChildPolicy(@PathVariable("childId") Long childId) {
+    public ApiResponse<PolicyResponse> getChildPolicy(
+            @AuthenticationPrincipal AuthMember authMember,
+            @PathVariable("childId") Long childId) {
+
+        Children authenticatedChild = authMember.asChildren();
+        if (!authenticatedChild.getId().equals(childId)) {
+            throw new ProjectException(GeneralErrorCode.FORBIDDEN);
+        }
 
         // Service를 호출하여 이번 달 정책과 차단 앱 목록을 가져옴
         PolicyResponse response = childPolicyService.getChildPolicy(childId);

--- a/src/main/java/me/sogom/bridge/domain/policy/dto/PolicyReqDTO.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/dto/PolicyReqDTO.java
@@ -2,6 +2,7 @@ package me.sogom.bridge.domain.policy.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 
 public class PolicyReqDTO {
@@ -12,6 +13,10 @@ public class PolicyReqDTO {
             Long childId,
 
             @NotBlank(message = "년월을 입력해 주세요.")
+            @Pattern(
+                    regexp = "\\d{4}-(0[1-9]|1[0-2])",
+                    message = "년월은 yyyy-MM 형식이어야 합니다."
+            )
             String yearMonth,
 
             @NotNull(message = "기본 시간을 입력해 주세요.")
@@ -19,4 +24,3 @@ public class PolicyReqDTO {
             Integer baseTime
     ) {}
 }
-

--- a/src/main/java/me/sogom/bridge/domain/policy/dto/PolicyResponse.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/dto/PolicyResponse.java
@@ -10,6 +10,7 @@ import java.util.List;
 public class PolicyResponse {
 
     //시간 정책 관련 데이터
+    private String yearMonth;          // 정책이 적용되는 년월 (예: "2026-06")
     private int totalAvailableTime;    // 이번 달 쓸 수 있는 총 시간 (기본 + 보상 합계)
     private int baseTime;              // 부모님이 설정한 순수 기본 시간
     private int accumulatedRewardTime; // 미션으로 모은 보상 시간

--- a/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
@@ -47,26 +47,14 @@ public class TimePolicy extends BaseEntity {
 
     public void updateBaseTime(int baseTime) { this.baseTime = baseTime; }
 
-    //기본 제공 시간과 보상 시간을 합쳐서 연장할 시간을 차감 (기본 시간에서 먼저 차감하고, 부족하면 보상 시간에서 차감)
-
-    public void deductAvailableTime(int minutes) {
-        int totalAvailable = this.baseTime + this.accumulatedRewardTime;
-
-        // 전체 가용 시간(기본+보상)이 연장하려는 시간보다 적은지 검문
-        if (totalAvailable < minutes) {
-            throw new IllegalArgumentException("사용 가능한 총 시간(기본+보상)이 부족하여 연장할 수 없습니다.");
+    public void deductRewardTime(int minutes) {
+        if (minutes <= 0) {
+            throw new IllegalArgumentException("사용할 보상 시간은 0보다 커야 합니다.");
         }
-
-        // 기본 시간이 충분히 남아있다면 기본 시간에서만 차감
-        if (this.baseTime >= minutes) {
-            this.baseTime -= minutes;
+        if (this.accumulatedRewardTime < minutes) {
+            throw new IllegalArgumentException("사용 가능한 보상 시간이 부족하여 연장할 수 없습니다.");
         }
-        // 기본 시간이 모자라다면, 기본 시간을 0으로 만들고 남은 만큼을 보상 시간에서 차감
-        else {
-            int remainder = minutes - this.baseTime;
-            this.baseTime = 0;
-            this.accumulatedRewardTime -= remainder;
-        }
+        this.accumulatedRewardTime -= minutes;
     }
     //자녀가 당일에 쓰지 않고 남긴 시간을 보상 시간 풀로 다시 환불(적립)해주는 메서드
     public void refundUnusedTime(int unusedMinutes) {

--- a/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
@@ -47,15 +47,27 @@ public class TimePolicy extends BaseEntity {
 
     public void updateBaseTime(int baseTime) { this.baseTime = baseTime; }
 
-    public void deductRewardTime(int minutes) {
+    // 기본 제공 시간과 보상 시간을 합쳐서 사용할 시간을 차감한다.
+    // 기본 시간이 먼저 소진되고, 부족한 부분만 보상 시간에서 차감된다.
+    public void deductAvailableTime(int minutes) {
         if (minutes <= 0) {
-            throw new IllegalArgumentException("사용할 보상 시간은 0보다 커야 합니다.");
+            throw new IllegalArgumentException("사용할 시간은 0보다 커야 합니다.");
         }
-        if (this.accumulatedRewardTime < minutes) {
-            throw new IllegalArgumentException("사용 가능한 보상 시간이 부족하여 연장할 수 없습니다.");
+        int totalAvailable = this.baseTime + this.accumulatedRewardTime;
+        if (totalAvailable < minutes) {
+            throw new IllegalArgumentException("사용 가능한 총 시간(기본+보상)이 부족하여 연장할 수 없습니다.");
         }
-        this.accumulatedRewardTime -= minutes;
+
+        if (this.baseTime >= minutes) {
+            this.baseTime -= minutes;
+            return;
+        }
+
+        int remainder = minutes - this.baseTime;
+        this.baseTime = 0;
+        this.accumulatedRewardTime -= remainder;
     }
+
     //자녀가 당일에 쓰지 않고 남긴 시간을 보상 시간 풀로 다시 환불(적립)해주는 메서드
     public void refundUnusedTime(int unusedMinutes) {
         if (unusedMinutes < 0) {

--- a/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
@@ -60,12 +60,12 @@ public class TimePolicy extends BaseEntity {
 
         if (this.baseTime >= minutes) {
             this.baseTime -= minutes;
-            return;
         }
-
-        int remainder = minutes - this.baseTime;
-        this.baseTime = 0;
-        this.accumulatedRewardTime -= remainder;
+        else {
+            int remainder = minutes - this.baseTime;
+            this.baseTime = 0;
+            this.accumulatedRewardTime -= remainder;
+        }
     }
 
     //자녀가 당일에 쓰지 않고 남긴 시간을 보상 시간 풀로 다시 환불(적립)해주는 메서드

--- a/src/main/java/me/sogom/bridge/domain/policy/service/ChildPolicyService.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/service/ChildPolicyService.java
@@ -35,6 +35,7 @@ public class ChildPolicyService {
 
         //엔티티들을 DTO로 변환하여 반환
         return PolicyResponse.builder()
+                .yearMonth(timePolicy.getYearMonth())
                 .totalAvailableTime(timePolicy.getTotalAvailableTime())
                 .baseTime(timePolicy.getBaseTime())
                 .accumulatedRewardTime(timePolicy.getAccumulatedRewardTime())

--- a/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/controller/ScheduleController.java
@@ -106,7 +106,7 @@ public class ScheduleController {
     public ApiResponse<String> deleteRoutine(
             @AuthenticationPrincipal AuthMember user,
             @PathVariable Long routineId) {
-        scheduleService.deleteRoutine(routineId);
+        scheduleService.deleteRoutine(user.asChildren().getId(), routineId);
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, "일정이 정상적으로 삭제되었습니다.");
     }
 
@@ -117,6 +117,15 @@ public class ScheduleController {
             @RequestBody List<WeeklyBudgetRequest> requests) { //리스트 내부 객체 타입 명시
 
         scheduleService.createWeeklyBudgets(user.asChildren().getId(), yearMonth, requests);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, null);
+    }
+
+    @PostMapping("/complete")
+    public ApiResponse<Void> completeTimePlan(
+            @AuthenticationPrincipal AuthMember user,
+            @RequestParam String yearMonth) {
+
+        scheduleService.completeTimePlan(user.asChildren().getId(), yearMonth);
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, null);
     }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/DailyScheduleResponse.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/DailyScheduleResponse.java
@@ -25,4 +25,14 @@ public class DailyScheduleResponse {
                 .totalAvailableMinutes(allocation.getTotalAvailableTime())
                 .build();
     }
+
+    public static DailyScheduleResponse preview(LocalDate targetDate, int baseMinutes, int extendedMinutes) {
+        return DailyScheduleResponse.builder()
+                .id(null)
+                .targetDate(targetDate)
+                .baseMinutes(baseMinutes)
+                .extendedMinutes(extendedMinutes)
+                .totalAvailableMinutes(baseMinutes + extendedMinutes)
+                .build();
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/TimeExtensionRequest.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/TimeExtensionRequest.java
@@ -1,6 +1,7 @@
 package me.sogom.bridge.domain.schedule.dto;
 
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import java.time.LocalDate;
 @Getter
 @NoArgsConstructor
 public class TimeExtensionRequest {
+    @NotNull(message = "연장할 날짜를 입력해 주세요.")
     private LocalDate targetDate;
 
     @Min(value = 1, message = "연장할 시간은 1분 이상이어야 합니다.")

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/TimeSummaryResponse.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/TimeSummaryResponse.java
@@ -1,0 +1,16 @@
+package me.sogom.bridge.domain.schedule.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TimeSummaryResponse {
+    private boolean parentPolicyExists;
+    private boolean childPlanExists;
+    private String todayScheduleStatus;
+    private String yearMonth;
+    private int basePolicyMinutes;
+    private DailyScheduleResponse todaySchedule;
+    private int rewardPoolMinutes;
+}

--- a/src/main/java/me/sogom/bridge/domain/schedule/repository/WeeklyTimeDistributionRepository.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/repository/WeeklyTimeDistributionRepository.java
@@ -17,6 +17,8 @@ public interface WeeklyTimeDistributionRepository extends JpaRepository<WeeklyTi
     // 특정 자녀의 '일주일치 전체' 템플릿 조회 (자녀가 주간 계획표 화면을 열었을 때 사용)
     List<WeeklyTimeDistribution> findAllByChildId(Long childId);
 
+    List<WeeklyTimeDistribution> findAllByChildIdAndYearMonth(Long childId, String yearMonth);
+
     // 특정 주차의 월~일 설정 리스트 전체 조회
     List<WeeklyTimeDistribution> findAllByChildIdAndYearMonthAndWeekNumber(Long childId, String yearMonth, int weekNumber);
 

--- a/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
@@ -62,10 +62,13 @@ public class ScheduleService {
                                     childId, dayOfWeek, yearMonth, weekNumber)
                             .orElseThrow(() -> new IllegalArgumentException("해당 요일의 기본 시간표 설정이 없습니다."));
 
-                    // 이번 달 부모 정책 존재 여부만 확인한다. TimePolicy.baseTime은
-                    // 부모가 설정한 월 총량이므로 일별 allocation 생성만으로 차감하지 않는다.
-                    timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
+                    // 이번 달 부모 정책 가져오기
+                    TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
                             .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책이 설정되지 않았습니다."));
+
+                    // 템플릿에 설정된 시간만큼 기본 시간에서 선차감 진행
+                    policy.deductAvailableTime(template.getBaseMinutes());
+                    timePolicyRepository.save(policy);
 
                     // 자녀 엔티티 조회
                     Children child = childrenRepository.findById(childId).orElseThrow();
@@ -84,6 +87,10 @@ public class ScheduleService {
 
     @Transactional(readOnly = true)
     public boolean hasChildPlan(Long childId, String yearMonth) {
+        if (timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth).isEmpty()) {
+            return false;
+        }
+
         List<WeeklyBudget> budgets = weeklyBudgetRepository.findAllByChildIdAndYearMonth(childId, yearMonth);
         Set<Integer> budgetWeeks = budgets.stream()
                 .map(WeeklyBudget::getWeekNumber)
@@ -109,11 +116,18 @@ public class ScheduleService {
             return false;
         }
 
-        return timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
-                .map(policy -> budgets.stream()
-                        .mapToInt(WeeklyBudget::getAllocatedMinutes)
-                        .sum() == policy.getBaseTime())
-                .orElse(false);
+        return true;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Integer> findMonthlyBudgetTotal(Long childId, String yearMonth) {
+        List<WeeklyBudget> budgets = weeklyBudgetRepository.findAllByChildIdAndYearMonth(childId, yearMonth);
+        if (budgets.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(budgets.stream()
+                .mapToInt(WeeklyBudget::getAllocatedMinutes)
+                .sum());
     }
 
     @Transactional
@@ -195,8 +209,8 @@ public class ScheduleService {
         TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
                 .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책이 설정되지 않았습니다."));
 
-        // 오늘 시간 연장은 미션으로 쌓인 보상 풀에서만 사용한다. 부모 월 총량은 재분배 기준이라 차감하지 않는다.
-        policy.deductRewardTime(extraMinutes);
+        // 기본 시간에서 먼저 차감하고, 부족한 경우 보상 시간에서 차감한다.
+        policy.deductAvailableTime(extraMinutes);
 
         //오늘의 스케줄 데이터를 가져오기
         DailyTimeAllocation allocation = getOrCreateDailyAllocation(childId, targetDate);
@@ -280,8 +294,7 @@ public class ScheduleService {
         routineRepository.delete(routine);
     }
     /**
-     하루 마무리 또는 앱 pause 시점에 실제 사용 시간을 coarse sync로 기록한다.
-     남은 시간을 보상 풀로 환불하지 않는다.
+     하루 마무리 시 실제 사용 시간을 기록하고 남은 시간을 보상 풀로 환불한다.
      * @param actualUsedMinutes 자녀가 오늘 실제로 스마트폰을 사용한 시간 (분 단위)
      */
     @Transactional
@@ -300,6 +313,18 @@ public class ScheduleService {
         // 가드 로직: 혹시 실제 사용 시간이 준 시간보다 많으면 연산 오류이므로 방어
         if (actualUsedMinutes > totalAllocatedTime) {
             throw new IllegalArgumentException("실제 사용 시간이 할당된 총 시간을 초과할 수 없습니다.");
+        }
+
+        // 남은 시간 계산하기 (할당량 - 실제 사용량)
+        int unusedMinutes = totalAllocatedTime - actualUsedMinutes;
+
+        // 남은 시간이 존재한다면 부모 정책(TimePolicy) 데이터에 환불 절차 진행
+        if (unusedMinutes > 0) {
+            String yearMonth = targetDate.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+            TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
+                    .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책을 찾을 수 없습니다."));
+
+            policy.refundUnusedTime(unusedMinutes);
         }
 
         // 오늘자 할당 기록의 baseMinutes와 extendedMinutes를 정산된 결과에 맞게 재조정

--- a/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
@@ -2,12 +2,16 @@ package me.sogom.bridge.domain.schedule.service;
 
 import lombok.RequiredArgsConstructor;
 import me.sogom.bridge.domain.member.entity.Children;
+import me.sogom.bridge.domain.member.entity.Parent;
 import me.sogom.bridge.domain.member.repository.ChildrenRepository;
+import me.sogom.bridge.domain.notification.entity.NotificationType;
+import me.sogom.bridge.domain.notification.service.NotificationService;
 import me.sogom.bridge.domain.policy.entity.TimePolicy;
 import me.sogom.bridge.domain.policy.repository.TimePolicyRepository;
 import me.sogom.bridge.domain.schedule.dto.RoutineRequest;
 import me.sogom.bridge.domain.schedule.dto.WeeklyBudgetRequest;
 import me.sogom.bridge.domain.schedule.dto.WeeklyTemplateRequest;
+import me.sogom.bridge.domain.schedule.dto.DailyScheduleResponse;
 import me.sogom.bridge.domain.schedule.entity.DailyTimeAllocation;
 import me.sogom.bridge.domain.schedule.entity.WeeklyBudget;
 import me.sogom.bridge.domain.schedule.entity.WeeklyRoutine;
@@ -16,13 +20,21 @@ import me.sogom.bridge.domain.schedule.repository.DailyTimeAllocationRepository;
 import me.sogom.bridge.domain.schedule.repository.WeeklyBudgetRepository;
 import me.sogom.bridge.domain.schedule.repository.WeeklyRoutineRepository;
 import me.sogom.bridge.domain.schedule.repository.WeeklyTimeDistributionRepository;
+import me.sogom.bridge.global.apiPayload.code.GeneralErrorCode;
+import me.sogom.bridge.global.apiPayload.exception.ProjectException;
+import me.sogom.bridge.global.security.entity.MemberRole;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +46,7 @@ public class ScheduleService {
     private final TimePolicyRepository timePolicyRepository;
     private final WeeklyRoutineRepository routineRepository;
     private final WeeklyBudgetRepository weeklyBudgetRepository;
+    private final NotificationService notificationService;
 
     //오늘의 실제 제한 시간 조회 (없으면 요일 템플릿에서 동적 복사)
     @Transactional
@@ -41,23 +54,18 @@ public class ScheduleService {
         // 오늘 날짜의 데이터가 이미 있는지 DB에서 확인
         return dailyRepository.findByChildIdAndTargetDate(childId, targetDate)
                 .orElseGet(() -> {
-                    // 없다면 오늘이 무슨 요일인지 확인
                     DayOfWeek dayOfWeek = targetDate.getDayOfWeek();
+                    String yearMonth = yearMonthOf(targetDate);
+                    int weekNumber = weekNumberOf(targetDate);
 
-                    // 해당 요일의 '기본 템플릿(Weekly)'을 가져오기
-                    WeeklyTimeDistribution template = weeklyRepository.findByChildIdAndDayOfWeek(childId, dayOfWeek)
+                    WeeklyTimeDistribution template = weeklyRepository.findByChildIdAndDayOfWeekAndYearMonthAndWeekNumber(
+                                    childId, dayOfWeek, yearMonth, weekNumber)
                             .orElseThrow(() -> new IllegalArgumentException("해당 요일의 기본 시간표 설정이 없습니다."));
 
-                    // 이번 달 부모 정책 가져오기
-                    String yearMonth = targetDate.format(DateTimeFormatter.ofPattern("yyyy-MM"));
-                    TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
+                    // 이번 달 부모 정책 존재 여부만 확인한다. TimePolicy.baseTime은
+                    // 부모가 설정한 월 총량이므로 일별 allocation 생성만으로 차감하지 않는다.
+                    timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
                             .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책이 설정되지 않았습니다."));
-
-                    // 템플릿에 설정된 설정 시간만큼 기본 시간에서 선차감 진행
-                    policy.deductAvailableTime(template.getBaseMinutes());
-
-                    // 변경된 상태를 DB에 확실하게 즉시 업데이트(UPDATE)
-                    timePolicyRepository.save(policy);
 
                     // 자녀 엔티티 조회
                     Children child = childrenRepository.findById(childId).orElseThrow();
@@ -74,9 +82,111 @@ public class ScheduleService {
                 });
     }
 
+    @Transactional(readOnly = true)
+    public boolean hasChildPlan(Long childId, String yearMonth) {
+        List<WeeklyBudget> budgets = weeklyBudgetRepository.findAllByChildIdAndYearMonth(childId, yearMonth);
+        Set<Integer> budgetWeeks = budgets.stream()
+                .map(WeeklyBudget::getWeekNumber)
+                .collect(Collectors.toSet());
+        Map<Integer, Integer> templateMinutesByWeek = weeklyRepository.findAllByChildIdAndYearMonth(childId, yearMonth).stream()
+                .collect(Collectors.groupingBy(
+                        WeeklyTimeDistribution::getWeekNumber,
+                        Collectors.summingInt(WeeklyTimeDistribution::getBaseMinutes)
+                ));
+
+        Set<Integer> requiredWeeks = Set.of(1, 2, 3, 4);
+        if (!budgetWeeks.containsAll(requiredWeeks) || !templateMinutesByWeek.keySet().containsAll(requiredWeeks)) {
+            return false;
+        }
+
+        boolean weeklyTemplatesMatchBudgets = budgets.stream()
+                .filter(budget -> requiredWeeks.contains(budget.getWeekNumber()))
+                .allMatch(budget ->
+                        templateMinutesByWeek.getOrDefault(budget.getWeekNumber(), 0)
+                                == budget.getAllocatedMinutes()
+                );
+        if (!weeklyTemplatesMatchBudgets) {
+            return false;
+        }
+
+        return timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
+                .map(policy -> budgets.stream()
+                        .mapToInt(WeeklyBudget::getAllocatedMinutes)
+                        .sum() == policy.getBaseTime())
+                .orElse(false);
+    }
+
+    @Transactional
+    public void clearChildPlan(Long childId, String yearMonth) {
+        weeklyBudgetRepository.deleteAll(weeklyBudgetRepository.findAllByChildIdAndYearMonth(childId, yearMonth));
+        weeklyRepository.deleteAll(weeklyRepository.findAllByChildIdAndYearMonth(childId, yearMonth));
+
+        YearMonth targetMonth = YearMonth.parse(yearMonth);
+        dailyRepository.deleteAll(dailyRepository.findAllByChildIdAndTargetDateBetween(
+                childId,
+                targetMonth.atDay(1),
+                targetMonth.atEndOfMonth()
+        ));
+    }
+
+    @Transactional
+    public void completeTimePlan(Long childId, String yearMonth) {
+        if (!hasChildPlan(childId, yearMonth)) {
+            throw new IllegalArgumentException("시간 계획이 아직 완료되지 않았습니다.");
+        }
+
+        Children child = childrenRepository.findById(childId).orElseThrow();
+        Parent parent = child.getParent();
+        if (parent == null) {
+            return;
+        }
+
+        notificationService.createNotification(
+                parent.getId(),
+                MemberRole.PARENT,
+                "시간 계획 완료",
+                child.getName() + "님이 " + yearMonth + " 사용 시간 설정을 완료했습니다.",
+                NotificationType.GENERAL,
+                child.getId(),
+                null,
+                null,
+                "/today-time?childrenId=" + child.getId()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<DailyScheduleResponse> findDailySchedulePreview(Long childId, LocalDate targetDate) {
+        Optional<DailyTimeAllocation> allocation = dailyRepository.findByChildIdAndTargetDate(childId, targetDate);
+        if (allocation.isPresent()) {
+            return allocation.map(DailyScheduleResponse::from);
+        }
+
+        String yearMonth = yearMonthOf(targetDate);
+        int weekNumber = weekNumberOf(targetDate);
+        DayOfWeek dayOfWeek = targetDate.getDayOfWeek();
+
+        return weeklyRepository.findByChildIdAndDayOfWeekAndYearMonthAndWeekNumber(
+                        childId, dayOfWeek, yearMonth, weekNumber)
+                .map(template -> DailyScheduleResponse.preview(targetDate, template.getBaseMinutes(), 0));
+    }
+
+    public String yearMonthOf(LocalDate targetDate) {
+        return targetDate.format(DateTimeFormatter.ofPattern("yyyy-MM"));
+    }
+
+    public int weekNumberOf(LocalDate targetDate) {
+        return Math.min(((targetDate.getDayOfMonth() - 1) / 7) + 1, 4);
+    }
+
     //자녀가 여분(보상) 시간을 사용해 오늘 시간을 연장할 때
     @Transactional
     public DailyTimeAllocation extendDailyTime(Long childId, LocalDate targetDate, int extraMinutes) {
+        if (targetDate == null) {
+            throw new IllegalArgumentException("연장할 날짜를 입력해 주세요.");
+        }
+        if (extraMinutes <= 0) {
+            throw new IllegalArgumentException("연장할 시간은 1분 이상이어야 합니다.");
+        }
 
         //날짜 변환 ("yyyy-MM" 형태)
         String yearMonth = targetDate.format(DateTimeFormatter.ofPattern("yyyy-MM"));
@@ -85,8 +195,8 @@ public class ScheduleService {
         TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
                 .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책이 설정되지 않았습니다."));
 
-        //엔티티의 차감 로직 호출 (알아서 기본시간->보상시간 순으로 깎고, 부족하면 에러를 던짐)
-        policy.deductAvailableTime(extraMinutes);
+        // 오늘 시간 연장은 미션으로 쌓인 보상 풀에서만 사용한다. 부모 월 총량은 재분배 기준이라 차감하지 않는다.
+        policy.deductRewardTime(extraMinutes);
 
         //오늘의 스케줄 데이터를 가져오기
         DailyTimeAllocation allocation = getOrCreateDailyAllocation(childId, targetDate);
@@ -100,6 +210,8 @@ public class ScheduleService {
     //요일별 기본 템플릿 설정 초과 등록 버그 수정
     @Transactional
     public void updateWeeklyTemplate(Long childId, WeeklyTemplateRequest request) {
+        validateWeeklyTemplateRequest(request);
+
         // 해당 월/주차에 자녀가 설정해둔 예산(WeeklyBudget) 가져오기
         WeeklyBudget weeklyBudget = weeklyBudgetRepository.findByChildIdAndYearMonthAndWeekNumber(
                         childId, request.getYearMonth(), request.getWeekNumber())
@@ -159,16 +271,24 @@ public class ScheduleService {
 
     //고정 일정 삭제
     @Transactional
-    public void deleteRoutine(Long routineId) {
-        WeeklyRoutine routine = routineRepository.findById(routineId).orElseThrow();
+    public void deleteRoutine(Long childId, Long routineId) {
+        WeeklyRoutine routine = routineRepository.findById(routineId)
+                .orElseThrow(() -> new ProjectException(GeneralErrorCode.NOT_FOUND));
+        if (routine.getChild() == null || !routine.getChild().getId().equals(childId)) {
+            throw new ProjectException(GeneralErrorCode.FORBIDDEN);
+        }
         routineRepository.delete(routine);
     }
     /**
-     하루 마무리 시 실제 사용 시간을 기록하고 남은 시간을 보상 풀로 환불하기
+     하루 마무리 또는 앱 pause 시점에 실제 사용 시간을 coarse sync로 기록한다.
+     남은 시간을 보상 풀로 환불하지 않는다.
      * @param actualUsedMinutes 자녀가 오늘 실제로 스마트폰을 사용한 시간 (분 단위)
      */
     @Transactional
     public DailyTimeAllocation settleDailyTime(Long childId, LocalDate targetDate, int actualUsedMinutes) {
+        if (actualUsedMinutes < 0) {
+            throw new IllegalArgumentException("실제 사용 시간은 음수일 수 없습니다.");
+        }
 
         // 1. 오늘의 스케줄 배정 데이터 가져오기
         DailyTimeAllocation allocation = dailyRepository.findByChildIdAndTargetDate(childId, targetDate)
@@ -180,19 +300,6 @@ public class ScheduleService {
         // 가드 로직: 혹시 실제 사용 시간이 준 시간보다 많으면 연산 오류이므로 방어
         if (actualUsedMinutes > totalAllocatedTime) {
             throw new IllegalArgumentException("실제 사용 시간이 할당된 총 시간을 초과할 수 없습니다.");
-        }
-
-        // 남은 시간 계산하기 (할당량 - 실제 사용량)
-        int unusedMinutes = totalAllocatedTime - actualUsedMinutes;
-
-        // 남은 시간이 존재한다면 부모 정책(TimePolicy) 데이터에 환불 절차 진행
-        if (unusedMinutes > 0) {
-            String yearMonth = targetDate.format(DateTimeFormatter.ofPattern("yyyy-MM"));
-            TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
-                    .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책을 찾을 수 없습니다."));
-
-            // TimePolicy의 보상 풀에 남은 시간만큼 플러스(+) 처리
-            policy.refundUnusedTime(unusedMinutes);
         }
 
         // 오늘자 할당 기록의 baseMinutes와 extendedMinutes를 정산된 결과에 맞게 재조정
@@ -208,18 +315,21 @@ public class ScheduleService {
         TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
                 .orElseThrow(() -> new IllegalArgumentException("정책이 없습니다."));
 
+        validateFourWeekBudgetRequests(requests);
+
 // 2. 자녀가 요청한 1~4주차 시간의 총합 계산
         int totalRequestedMinutes = requests.stream()
                 .mapToInt(WeeklyBudgetRequest::getAllocatedMinutes)
                 .sum();
 
-// 3. 한 달 총량을 초과하는지 검증
-        if (totalRequestedMinutes > policy.getBaseTime()) {
-            throw new IllegalArgumentException("주차별 분배 시간의 합이 한 달 총량을 초과할 수 없습니다.");
+// 3. 한 달 총량과 정확히 일치하는지 검증
+        if (totalRequestedMinutes != policy.getBaseTime()) {
+            throw new IllegalArgumentException("주차별 분배 시간의 합은 한 달 총량과 같아야 합니다.");
         }
 
-// 4. 기존 데이터가 있다면 삭제 후 새로 저장 (또는 update 처리)
+        // 기존 데이터가 있다면 삭제 후 새로 저장한다. 템플릿도 함께 비워야 재시도/재설정 시 이전 요일이 섞이지 않는다.
         weeklyBudgetRepository.deleteAll(weeklyBudgetRepository.findAllByChildIdAndYearMonth(childId, yearMonth));
+        weeklyRepository.deleteAll(weeklyRepository.findAllByChildIdAndYearMonth(childId, yearMonth));
 
         Children child = childrenRepository.findById(childId).orElseThrow();
 
@@ -233,5 +343,44 @@ public class ScheduleService {
                 .toList();
 
         weeklyBudgetRepository.saveAll(budgets);
+    }
+
+    private void validateFourWeekBudgetRequests(List<WeeklyBudgetRequest> requests) {
+        if (requests == null) {
+            throw new IllegalArgumentException("1~4주차 예산을 모두 한 번씩 분배해야 합니다.");
+        }
+        if (requests.stream().anyMatch(request -> request == null)) {
+            throw new IllegalArgumentException("1~4주차 예산을 모두 한 번씩 분배해야 합니다.");
+        }
+
+        Set<Integer> requiredWeeks = Set.of(1, 2, 3, 4);
+        Set<Integer> requestedWeeks = requests.stream()
+                .map(WeeklyBudgetRequest::getWeekNumber)
+                .collect(Collectors.toSet());
+
+        if (requests.size() != requiredWeeks.size() || !requestedWeeks.equals(requiredWeeks)) {
+            throw new IllegalArgumentException("1~4주차 예산을 모두 한 번씩 분배해야 합니다.");
+        }
+
+        boolean hasNonPositiveBudget = requests.stream()
+                .anyMatch(request -> request.getAllocatedMinutes() <= 0);
+        if (hasNonPositiveBudget) {
+            throw new IllegalArgumentException("각 주차 예산은 0분보다 커야 합니다.");
+        }
+    }
+
+    private void validateWeeklyTemplateRequest(WeeklyTemplateRequest request) {
+        if (request == null
+                || request.getYearMonth() == null
+                || request.getYearMonth().isBlank()
+                || request.getDayOfWeek() == null) {
+            throw new IllegalArgumentException("요일별 시간 설정 값이 올바르지 않습니다.");
+        }
+        if (request.getWeekNumber() < 1 || request.getWeekNumber() > 4) {
+            throw new IllegalArgumentException("주차는 1~4주차만 설정할 수 있습니다.");
+        }
+        if (request.getBaseMinutes() < 0) {
+            throw new IllegalArgumentException("요일별 기본 시간은 음수일 수 없습니다.");
+        }
     }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
@@ -336,24 +336,31 @@ public class ScheduleService {
     }
     @Transactional
     public void createWeeklyBudgets(Long childId, String yearMonth, List<WeeklyBudgetRequest> requests) {
-// 1. 부모가 설정한 이번 달 총 가용 시간 조회
+        // 1. 부모가 설정한 이번 달 기본 시간 풀 조회
         TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
                 .orElseThrow(() -> new IllegalArgumentException("정책이 없습니다."));
 
         validateFourWeekBudgetRequests(requests);
 
-// 2. 자녀가 요청한 1~4주차 시간의 총합 계산
+        // 2. 자녀가 요청한 1~4주차 시간의 총합 계산
         int totalRequestedMinutes = requests.stream()
                 .mapToInt(WeeklyBudgetRequest::getAllocatedMinutes)
                 .sum();
 
-// 3. 한 달 총량과 정확히 일치하는지 검증
-        if (totalRequestedMinutes != policy.getBaseTime()) {
+        List<WeeklyBudget> existingBudgets = weeklyBudgetRepository.findAllByChildIdAndYearMonth(childId, yearMonth);
+        int monthlyBudgetLimit = existingBudgets.isEmpty()
+                ? policy.getBaseTime()
+                : existingBudgets.stream()
+                        .mapToInt(WeeklyBudget::getAllocatedMinutes)
+                        .sum();
+
+        // 3. 한 달 분배 기준과 정확히 일치하는지 검증
+        if (totalRequestedMinutes != monthlyBudgetLimit) {
             throw new IllegalArgumentException("주차별 분배 시간의 합은 한 달 총량과 같아야 합니다.");
         }
 
         // 기존 데이터가 있다면 삭제 후 새로 저장한다. 템플릿도 함께 비워야 재시도/재설정 시 이전 요일이 섞이지 않는다.
-        weeklyBudgetRepository.deleteAll(weeklyBudgetRepository.findAllByChildIdAndYearMonth(childId, yearMonth));
+        weeklyBudgetRepository.deleteAll(existingBudgets);
         weeklyRepository.deleteAll(weeklyRepository.findAllByChildIdAndYearMonth(childId, yearMonth));
 
         Children child = childrenRepository.findById(childId).orElseThrow();

--- a/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
@@ -347,19 +347,20 @@ public class ScheduleService {
                 .mapToInt(WeeklyBudgetRequest::getAllocatedMinutes)
                 .sum();
 
-        List<WeeklyBudget> existingBudgets = weeklyBudgetRepository.findAllByChildIdAndYearMonth(childId, yearMonth);
-        int monthlyBudgetLimit = existingBudgets.isEmpty()
-                ? policy.getBaseTime()
-                : existingBudgets.stream()
-                        .mapToInt(WeeklyBudget::getAllocatedMinutes)
-                        .sum();
-
-        // 3. 한 달 분배 기준과 정확히 일치하는지 검증
-        if (totalRequestedMinutes != monthlyBudgetLimit) {
-            throw new IllegalArgumentException("주차별 분배 시간의 합은 한 달 총량과 같아야 합니다.");
+        // 3. 한 달 총량을 초과하는지 검증
+        if (totalRequestedMinutes > policy.getBaseTime()) {
+            throw new IllegalArgumentException("주차별 분배 시간이 한 달 총량을 초과할 수 없습니다.");
         }
 
-        // 기존 데이터가 있다면 삭제 후 새로 저장한다. 템플릿도 함께 비워야 재시도/재설정 시 이전 요일이 섞이지 않는다.
+        // 기존 데이터 조회
+        List<WeeklyBudget> existingBudgets =
+                weeklyBudgetRepository.findAllByChildIdAndYearMonth(
+                        childId,
+                        yearMonth
+                );
+
+        // 기존 데이터가 있다면 삭제 후 새로 저장한다.
+        // 템플릿도 함께 비워야 재시도/재설정 시 이전 요일이 섞이지 않는다.
         weeklyBudgetRepository.deleteAll(existingBudgets);
         weeklyRepository.deleteAll(weeklyRepository.findAllByChildIdAndYearMonth(childId, yearMonth));
 

--- a/src/main/java/me/sogom/bridge/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/me/sogom/bridge/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -38,6 +38,16 @@ public class GeneralExceptionAdvice {
                 .body(ApiResponse.onFailure(code, message));
     }
 
+    // 서비스 레이어의 선행 조건/검증 실패는 클라이언트가 바로 수정할 수 있는 400으로 응답한다.
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse<String>> handleIllegalArgumentException(
+            IllegalArgumentException e
+    ) {
+        BaseErrorCode code = GeneralErrorCode.BAD_REQUEST;
+        return ResponseEntity.status(code.getStatus())
+                .body(ApiResponse.onFailure(code, e.getMessage()));
+    }
+
     // 그 외의 정의되지 않은 모든 예외 처리
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<String>> handleException(


### PR DESCRIPTION
## 작업 내용
- 부모 앱에서 자녀별 오늘의 시간 상태를 조회할 수 있도록 `/api/v1/parents/children/{childId}/time-summary`를 추가했습니다.
- 부모의 월간 시간 정책 등록과 자녀의 주간/일간 시간 계획 완료 흐름을 앱 계약에 맞게 보강했습니다.
- 자녀 홈의 일간 스케줄/연장/정산 응답에서 남은 시간, reward pool, 자녀 계획 존재 여부를 사용할 수 있도록 응답을 정리했습니다.
- 미션 등록/조회/수행 제출/승인/반려 흐름의 소유자 검증과 상태 전이를 보강했습니다.
- 알림 생성/조회/읽음/삭제와 FCM payload 구성을 앱에서 쓰는 형태에 맞췄습니다.
- 자녀 등록 시 `childrenBirth`는 `2015` 같은 4자리 연도만 받도록 검증을 추가했습니다.
- 로컬 실행 편의를 위해 `docker-compose.yml`과 README 보충을 포함했습니다.

## 시간 정책 기준 정리
- 기존 백엔드 설계를 유지해 `TimePolicy.baseTime`은 daily 생성/오늘 시간 연장 시 먼저 차감되는 기본 시간 풀로 봅니다.
- `accumulatedRewardTime`은 미션 보상뿐 아니라 하루 정산 시 미사용 시간이 환불되어 누적되는 reward pool로 봅니다.
- 오늘 시간 연장은 `baseTime`에서 먼저 차감하고, 부족한 경우 `accumulatedRewardTime`에서 차감합니다.
- 자녀가 이미 계획을 저장한 뒤에는 `baseTime`이 선차감으로 줄어 있을 수 있으므로, 원래 월 배정량 표시/재저장 검증에는 기존 `WeeklyBudget` 합계를 우선 사용합니다.

## 리뷰 반영
- 삭제됐던 미사용 시간 환불 흐름을 복구했습니다.
- daily schedule 생성 시 template 시간만큼 기본 시간에서 선차감하는 흐름을 복구했습니다.
- 기본 시간 먼저 차감 후 부족분을 reward pool에서 차감하는 `deductAvailableTime` 흐름을 유지했습니다.
- 자녀 계획 재저장 시 줄어든 `baseTime` 때문에 기존 월 배정량과 충돌하지 않도록 기존 `WeeklyBudget` 합계를 기준으로 검증하도록 보완했습니다.
- `WeeklyTimeDistributionRepository.findAllByChildIdAndYearMonth`는 `WeeklyBudgetRepository`와 대상 엔티티가 달라 `childPlanExists`와 plan 초기화에 필요하므로 유지했습니다.

## 참고
- 백엔드 요청에 따라 이번 PR에는 테스트코드를 포함하지 않았습니다.
- 기존 작업 브랜치의 테스트 추가분은 PR용 브랜치로 옮기지 않았고, `src/test` 변경이 없는 상태입니다.
- 현재 PR은 draft 상태입니다.

## 검증
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH bash ./gradlew test`
