### PR TITLE
[codex] 월간 남은시간 및 오늘 시간 연장 API 정리

### DIFF
--- a/claudedocs/app-change-phases.md
+++ b/claudedocs/app-change-phases.md
@@ -1,0 +1,233 @@
+# App Change Phases
+
+작성일: 2026-06-08  
+대상: Quad-S Parent/Child Flutter apps  
+목표: 백엔드 작업을 PR #53 수준에서 더 늘리지 않고, 부스 시연 core flow를 앱 변경으로 살린다.
+
+## 0. 판단 요약
+
+내부 검토 결과, 시연에 필요한 앱 변경은 "모든 API 완성"이 아니라 아래 흐름을 안정화하는 것이다.
+
+1. 자녀가 MyPage에서 자기 `childCode`를 확인한다.
+2. 부모가 `childCode`로 자녀를 등록한다.
+3. 부모가 1분 또는 짧은 시간을 설정한다.
+4. 자녀 앱이 남은 시간을 표시하고 카운트다운한다.
+5. 시간이 0이 되면 앱 차단을 발동한다.
+6. 자녀가 미션을 수행하면 보상 시간이 증가한 것을 확인한다.
+
+따라서 리포트, profile update, 자녀 연결 해제, 알림 deeplink, usage ingestion은 이번 시연 MVP에서 제외한다.
+
+## Phase 1. Child Code 저장/표시
+
+목적: 별도 `members/me` API 없이, backend PR #53의 auth 응답만으로 자녀 코드를 MyPage에 표시한다.
+
+### Backend 의존성
+
+- PR #53 배포 필요
+- `AuthResponse.childCode`가 child login/signup/refresh 응답에 포함되어야 함
+- live Swagger에 아직 없으면 이 phase는 앱 코드를 넣어도 실제 값 확인이 불가
+
+### Child 앱 변경
+
+대상 repo: `/Users/yeongj/Quad-S-Team12-App-Child`
+
+변경 파일 후보:
+- `lib/features/auth/data/models/auth_token.dart`
+- `lib/features/auth/data/repositories/api_auth_repository.dart`
+- `lib/core/auth/auth_session.dart`
+- `lib/features/login/presentation/pages/login_page.dart`
+- `lib/features/signup/presentation/pages/signup_page.dart`
+- `lib/features/my_page/data/repositories/api_my_page_repository.dart`
+
+작업:
+- `AuthToken`에 nullable `childCode` 추가
+- `_parseTokenResponse()`에서 `childCode` 파싱
+- 로그인 성공 시 `AuthSession`에 `childCode` 저장
+- 회원가입은 tokenless 결과일 수 있으므로, code 저장은 login success 경로 중심으로 처리
+- MyPage repository에서 hardcoded `XY785eZ` 제거
+- 저장된 code가 없으면 `'-'` 또는 "다시 로그인 필요" 수준의 안전한 fallback 표시
+
+완료 기준:
+- 자녀 로그인 후 MyPage의 `자녀코드`가 backend 응답값을 표시
+- 로그아웃 후 재로그인하면 code가 복구
+- 기존 mock mode는 mock childCode를 계속 표시
+
+검증:
+- `flutter analyze`
+- `flutter test`
+- PR #53 배포 후 실제 자녀 로그인으로 MyPage 확인
+
+## Phase 2. 시간/차단 시연 루프
+
+목적: 부모가 짧은 시간을 설정하고, 자녀 앱이 카운트다운 후 차단을 발동한다.
+
+### Backend 의존성
+
+추가 backend 작업 없음. 현재 Swagger 경로 사용:
+- Parent: `POST /api/v1/parents/time-policy`
+- Child: `GET /api/v1/schedules/daily?date=YYYY-MM-DD`
+- 선택: `GET /api/v1/children/{childId}/policies`
+
+주의:
+- Child 앱이 자기 `childId/memberId`를 알아야 `children/{childId}/policies`를 직접 조회할 수 있음
+- PR #53의 `memberId`는 이미 auth response에 있음. Child 앱은 이 값을 세션에 저장해야 함
+
+### Child 앱 변경
+
+변경 파일 후보:
+- `lib/features/auth/data/models/auth_token.dart`
+- `lib/core/auth/auth_session.dart`
+- `lib/features/child_home/presentation/pages/child_home_page.dart`
+- `lib/features/time_confirm/data/repositories/api_time_confirm_repository.dart`
+- 필요 시 신규 `policy`/`home_time` repository
+
+작업:
+- Child auth session에 `memberId` 저장
+- Child home의 `_remainingMinutes = 90 + 30` hardcode 제거
+- `GET /api/v1/schedules/daily`의 `totalAvailableMinutes`를 홈 시간 카드/차단 판단에 사용
+- 시연 모드에서는 서버에서 받은 초기 분 단위 값을 앱 내부 timer로 초 단위 카운트다운
+- `remaining <= 0`이면 `DeviceBlockController.instance.applyForRemainingMinutes(0)` 또는 `setBlocked(true)` 호출
+- 권한이 없으면 permission flow를 먼저 유도
+
+### Parent 앱 변경
+
+대상 repo: `/Users/yeongj/Quad-S-Team12-App-Parent`
+
+현재 `saveMonthlyTotal()`은 `POST /api/v1/parents/time-policy`에 붙어 있음. 시연에서 1분 설정이 자연스럽게 가능하도록 UI 또는 입력 제한만 확인한다.
+
+변경 후보:
+- `lib/features/today_time/presentation/pages/monthly_time_setup_page.dart`
+- `lib/data/repositories/api_time_plan_repository.dart`
+
+작업:
+- 1분 같은 짧은 값이 UI에서 입력/저장 가능한지 확인
+- backend `@Positive` 때문에 0분은 금지, 1분 이상만 허용
+
+완료 기준:
+- 부모 앱에서 연결된 자녀에게 1분 정책 저장 성공
+- 자녀 앱 홈에서 1분 또는 설정값 기반 카운트다운 시작
+- 0초 도달 시 native block method 호출
+
+검증:
+- `flutter analyze`, `flutter test`
+- iOS/Android simulator 또는 실제 기기에서 blocker permission path 확인
+- 실제 차단은 platform capability가 필요하므로, 최소한 method channel 호출 성공/실패 로그를 확인
+
+## Phase 3. 미션 보상 시간 MVP
+
+목적: 자녀가 미션을 수행하면 backend가 보상 시간을 지급하고, 앱에서 증가를 확인한다.
+
+### Backend 의존성
+
+추가 backend 작업 없음. 현재 backend 로직:
+- `CHILD` verification: 제출 즉시 `ACCEPTED`, `TimePolicy.addReward(reward)`
+- `PARENT` verification: parent approve 시 `TimePolicy.addReward(reward)`
+- `AI` verification: AI accepted 시 `TimePolicy.addReward(reward)`
+
+시연 MVP는 가장 안정적인 `CHILD` verification부터 사용한다.
+
+### Child 앱 변경
+
+변경 파일 후보:
+- `lib/features/mission/data/repositories/api_mission_repository.dart`
+- `lib/features/mission/state/mission_controller.dart`
+- `lib/features/mission/data/models/mission.dart`
+- `lib/features/child_home/presentation/pages/child_home_page.dart`
+
+작업:
+- `submitMission()`이 `AiVerificationResponse`를 버리지 않고 반환하도록 모델링
+- `MissionController.submit()`에서 `isAccepted/reason`을 반영
+- 자녀 확인 방식은 성공 즉시 completed 화면 표시
+- 제출 성공 후 정책/시간 데이터를 refresh하여 보상 시간 증가를 홈 또는 완료 화면에서 확인
+- 실패/반려 reason은 Snackbar 또는 제출 완료 화면 subtitle로 표시
+
+완료 기준:
+- 자녀 확인 방식 미션 제출 후 성공 화면 표시
+- 보상 시간이 backend policy에 추가됨
+- 앱에서 보상 시간 증가 또는 총 사용 가능 시간 증가를 확인 가능
+
+검증:
+- `flutter analyze`, `flutter test`
+- 실제 flow: 부모가 reward 1분 미션 생성 -> 자녀 제출 -> policy `accumulatedRewardTime` 증가 확인
+
+## Phase 4. 부모 승인/반려 화면 보강
+
+목적: 부모 확인 방식 미션도 시연 가능하게 만든다. 단, MVP 이후 단계다.
+
+### Parent 앱 변경
+
+변경 파일 후보:
+- `lib/data/repositories/api_mission_repository.dart`
+- `lib/data/repositories/mission_repository.dart`
+- `lib/features/today_mission/presentation/models/today_mission.dart`
+- `lib/features/today_mission/presentation/pages/today_mission_check_page.dart`
+- `lib/features/today_mission/presentation/pages/today_mission_list_page.dart`
+
+작업:
+- `MissionRepository`에 mission detail/performance fetch 메서드 추가
+- `GET /api/v1/missions/{missionId}/performance` 응답의 `status`, `proofImageUrl`를 UI 모델에 매핑
+- Parent 미션 확인 화면 진입 시 최신 performance 상태를 조회
+- `PENDING`이면 승인/반려 버튼 표시
+- `ACCEPTED/REJECTED`이면 버튼 대신 결과 상태 표시
+- approve/reject 후 performance와 mission list refresh
+
+주의:
+- 현재 Parent 앱은 page-level index 기반이다. backend는 `missionId/performanceId` 기반이므로, 장기적으로는 UI 모델에 `missionId`를 보존하는 구조가 필요하다.
+- 단기 시연은 기존 index -> missionId 브릿지를 유지해도 된다.
+
+완료 기준:
+- 부모 확인 방식 미션 제출 후 Parent 앱에서 `PENDING` 확인 가능
+- 승인 클릭 시 backend approve 호출
+- 자녀 policy reward 증가
+- 반려 클릭 시 reward 미지급
+
+검증:
+- Parent/Child `flutter analyze`, `flutter test`
+- 실제 parent-confirm mission E2E
+
+## Phase 5. AI 미션/알림 안정화
+
+목적: AI verification과 notification route를 실서비스에 가깝게 정리한다. 시연 필수는 아니다.
+
+### Child 앱 변경
+
+- AI 미션 제출 결과의 `isAccepted/reason` 즉시 표시
+- `ApiMissionApprovalListener` no-op 제거 또는 polling으로 대체
+- Child notification repository가 AWS 배열 응답을 받도록 수정
+
+### Parent 앱 변경
+
+- 알림 payload가 없는 현재 backend에서는 알림 클릭 route를 신뢰하지 않음
+- backend가 payload를 추가하기 전까지 Parent 알림 action은 fallback routing만 유지
+
+완료 기준:
+- AI accepted/rejected 결과가 자녀 화면에 표시
+- Child 알림 목록이 live AWS 배열 응답에서 깨지지 않음
+
+검증:
+- `flutter analyze`, `flutter test`
+- 실제 AI 미션은 외부 AI 응답 변수가 있어 demo 필수 flow로 잡지 않음
+
+## Deferred
+
+이번 시연 범위에서 제외한다.
+
+| 항목 | 제외 이유 |
+| --- | --- |
+| Usage report / actual usage ingestion | 실제 사용량 수집/정산/리포트는 backend와 native 수집 설계가 필요 |
+| Profile update | childCode 표시에는 login response 저장만으로 충분 |
+| `GET /api/v1/members/me` | 있으면 좋지만 백엔드 작업량 증가. 이번에는 auth response 저장으로 대체 |
+| Child unlink/delete | 부스 core flow 아님 |
+| Parent full time-plan draft source of truth | 현재 월 총량 저장만으로 1분 차단 시연 가능 |
+| Notification deeplink/payload 통일 | 미션/차단 core flow와 분리 가능 |
+
+## 추천 실행 순서
+
+1. Phase 1: `childCode`/`memberId` 저장 및 MyPage 표시
+2. Phase 2: Child home time source + countdown/block trigger
+3. Phase 3: 자녀 확인 미션 보상 시간 refresh
+4. Phase 4: 부모 확인 미션 approve/reject UI 보강
+5. Phase 5: AI/알림 안정화
+
+부스 시연 최소 컷은 Phase 1-3이다. 부모 승인까지 보여주려면 Phase 4까지 진행한다.
+

--- a/claudedocs/aws-core-feature-audit.md
+++ b/claudedocs/aws-core-feature-audit.md
@@ -1,0 +1,197 @@
+# AWS Core Feature Audit
+
+작성일: 2026-06-08  
+대상: live AWS Swagger `https://leyoung.shop/v3/api-docs`, Parent 앱, Child 앱, backend 현재 브랜치
+
+## 1. 결론
+
+두 앱 모두 기본 환경은 `https://leyoung.shop` + `useMocks=false`로 맞춰져 있고, 앱 코드의 직접 HTTP 호출은 현재 Swagger에 있는 `/auth/*`, `/api/v1/*` 경로만 사용한다. 과거 compatibility endpoint 호출은 앱 코드 기준으로 남아 있지 않다.
+
+하지만 "경로"는 맞아도 core flow가 전부 실서비스 수준으로 살아난 상태는 아니다. 가장 큰 문제는 아래 5개다.
+
+| 우선순위 | 영역 | 상태 | 영향 |
+| --- | --- | --- | --- |
+| P0 | 자녀 코드 노출 | live AWS `AuthResponse`, `ChildrenInfoResponse`에 `childCode` 없음 | 신규 자녀가 자기 코드를 확인할 수 없어 부모-자녀 연결 bootstrap이 막힘 |
+| P0 | Child 알림 목록 | Child 앱은 `{ notifications: [...] }` 래퍼를 기대하지만 AWS는 `data: [...]` 배열 | Child 알림 화면이 실 API에서 로드 실패 가능 |
+| P1 | 앱 차단/화이트리스트 | 부모 화이트리스트는 로컬 저장, 자녀 blocker는 hardcoded remaining minutes | "앱 차단" core feature가 AWS 정책과 연결되지 않음 |
+| P1 | 알림 payload/FCM deeplink | AWS `NotificationResponse`와 FCM payload에 `payload`, `deeplink`, `missionId`, `childCode`가 없음 | 부모/자녀 앱 간 알림 기반 상호작용 라우팅이 약함 |
+| P1 | 리포트/실사용량 | Child 리포트는 daily schedule 7건에서 계획 시간만 조합하고 actualMinutes는 0 | 사용 리포트가 실제 사용량 기반이 아님 |
+
+## 2. 검수 기준
+
+- Swagger 수집: `curl -sS https://leyoung.shop/v3/api-docs`
+- Child 앱 직접 HTTP 호출: `rg`로 `Dio.get/post/put/patch/delete` 경로 확인
+- Parent 앱 직접 HTTP 호출: 동일 방식 확인
+- Backend 현재 브랜치 controller/service/DTO 확인
+- 정적/테스트 검증:
+  - Child: `flutter analyze` 통과, `flutter test` 통과
+  - Parent: `flutter analyze` 통과, `flutter test` 통과
+  - Backend: Java 21으로 `bash ./gradlew test` 통과
+
+주의: 위 테스트는 live AWS 통합 테스트가 아니라 로컬 정적/단위 테스트다. 실제 계정 생성, 부모-자녀 연결, 미션 제출까지 end-to-end로 AWS DB에 대해 수행한 검증은 아니다.
+
+## 3. Endpoint Coverage
+
+### Child 앱
+
+Child 앱은 현재 Swagger 경로만 호출한다.
+
+| 기능 | 앱 호출 | Swagger 존재 | 판정 |
+| --- | --- | --- | --- |
+| 자녀 로그인 | `POST /auth/children/login` | 있음 | OK |
+| 자녀 회원가입 | `POST /auth/children/signup` | 있음 | 부분 OK, childCode 저장/표시 안 됨 |
+| 토큰 갱신 | `POST /auth/token/refresh` | 있음 | OK |
+| FCM 토큰 | `POST /api/v1/fcm/token` | 있음 | OK, payload 라우팅은 별도 이슈 |
+| 오늘 시간표 | `GET /api/v1/schedules/daily` | 있음 | OK, 부모 정책/템플릿 선행 필요 |
+| 루틴 | `GET/POST/DELETE /api/v1/schedules/routines` | 있음 | OK |
+| 주차 예산 | `POST /api/v1/schedules/weekly-budgets` | 있음 | OK, parent time-policy 선행 필요 |
+| 요일 템플릿 | `PUT /api/v1/schedules/templates` | 있음 | OK |
+| 미션 목록/상세 | `GET /api/v1/missions`, `GET /api/v1/missions/{missionId}` | 있음 | OK |
+| 미션 인증 | `POST /api/v1/missions/{missionId}/performances` multipart `image` | 있음 | OK |
+| 알림 | `GET/PATCH/DELETE /api/v1/notifications...` | 있음 | P0 shape mismatch |
+| 비밀번호/탈퇴 | `PATCH/DELETE /api/v1/members...` | 있음 | OK |
+
+### Parent 앱
+
+Parent 앱도 현재 Swagger 경로만 호출한다.
+
+| 기능 | 앱 호출 | Swagger 존재 | 판정 |
+| --- | --- | --- | --- |
+| 부모 로그인/회원가입 | `POST /auth/parent/login`, `POST /auth/parent/signup` | 있음 | OK |
+| 토큰 갱신/로그아웃 | `POST /auth/token/refresh`, `POST /auth/logout` | 있음 | OK |
+| 자녀 목록/등록 | `GET/POST /api/v1/parents/children` | 있음 | OK, childCode가 사용자에게 전달되어야 함 |
+| 프로필 사진 | `POST /api/v1/files/photos?category=PROFILE` | 있음 | OK |
+| 월 총량 | `POST /api/v1/parents/time-policy` | 있음 | OK |
+| 자녀 정책 조회 | `GET /api/v1/children/{childId}/policies` | 있음 | OK |
+| 미션 | `GET/POST /api/v1/missions`, performance approve/reject | 있음 | 부분 OK, 수정/삭제는 AWS 경로 없음 |
+| 알림 | `GET/PATCH/DELETE /api/v1/notifications...` | 있음 | 목록 파싱 OK, payload 부족 |
+| FCM 토큰 | `POST /api/v1/fcm/token` | 있음 | OK |
+| 비밀번호/탈퇴 | `PATCH/DELETE /api/v1/members...` | 있음 | OK |
+
+## 4. 부모-자녀 식별자 흐름
+
+| 식별자 | 현재 역할 | 검수 결과 |
+| --- | --- | --- |
+| `childCode` | 부모가 자녀를 연결할 때 입력하는 bootstrap 코드 | backend 현재 브랜치에는 생성/응답 로직이 있지만 live AWS Swagger에는 아직 없음. Child 앱도 아직 토큰/프로필에 저장하지 않고 MyPage에서 hardcoded `XY785eZ`를 표시함 |
+| `childrenId` / `childId` | 연결 후 미션/시간/정책의 실제 DB 식별자 | Parent 앱은 자녀 목록에서 받은 `childrenId`를 후속 호출에 사용한다. 이 방향이 맞다 |
+| `parentId` | 앱 내부 세션/로컬 저장 키 | 서버 호출에는 대부분 보내지 않고 JWT로 부모를 식별한다. 이 방향이 맞다 |
+| `missionId` | 미션 상세/수행/성능 조회의 실제 식별자 | Child는 `missionId` 기반. Parent는 UI가 index 기반이라 매번 목록 조회 후 `missionId`를 찾아 approve/reject한다 |
+| `performanceId` | 부모 승인/반려의 실제 식별자 | Backend가 `GET /missions/{missionId}/performance` 후 `PATCH /performances/{performanceId}` 구조라 Parent 앱 구현과 맞음 |
+| `missionIndex` | 과거 Parent 알림 payload용 index | live AWS 알림에는 payload가 없어서 현재는 실효성이 낮음. 가능하면 `missionId`로 통일 필요 |
+
+판정: 자녀 코드는 연결 bootstrap에만 필요하고, 연결 이후 core domain flow는 `childrenId`/`childId` 기반이 맞다. 따라서 후속 작업은 `childCode`를 모든 기능에 퍼뜨리는 것이 아니라, 회원가입/로그인/자녀목록/마이페이지/부모 등록 화면까지만 정확히 노출하는 방향이 좋다.
+
+## 5. 기능별 세부 판정
+
+### Auth
+
+- Parent 로그인은 `email/password`만 보내며 live AWS schema와 맞다.
+- Parent 회원가입은 tokenless 응답도 허용하고 로그인 화면으로 넘긴다.
+- Child 회원가입은 `name/email/password`로 맞춰졌고 tokenless 응답 크래시는 방지됐다.
+- 현재 live AWS에는 `childCode`가 없으므로 Child 회원가입 직후 자녀 코드 표시가 불가능하다.
+- Backend 현재 브랜치의 PR #53은 `AuthResponse`, `ChildrenInfoResponse`에 `childCode`를 추가한다. 이 PR이 배포된 뒤 Child 앱이 `childCode`를 저장/표시하도록 후속 수정해야 한다.
+
+### Parent-Child 연결
+
+- Parent 앱의 `POST /api/v1/parents/children` body는 `{ childrenName, childrenCode, profileImageKey? }`로 Swagger와 맞다.
+- `childrenBirth`는 backend에서 optional이라 앱이 생략해도 된다.
+- 프로필 이미지는 `POST /api/v1/files/photos?category=PROFILE`로 S3 업로드 후 `profileImageKey`를 등록하므로 방향이 맞다.
+- live AWS가 자녀 코드를 노출하지 않는 동안에는 신규 자녀가 부모에게 줄 코드를 알 수 없어 연결이 막힌다.
+
+### Mission
+
+- 과거 blocker였던 "Child 미션 목록에 childId query가 필요하다" 문제는 현재 backend 기준으로 해소됐다. 자녀 JWT면 `GET /api/v1/missions`가 자기 미션을 반환한다.
+- Child 미션 인증도 현재 backend 기준 `image` multipart만 필요하다. `childId`, `category`, `prompt`는 서버에서 해석한다.
+- Parent 미션 생성 payload는 `childId/title/category/resetCycle/verificationType/reward/description`으로 Swagger와 맞다.
+- Parent 미션 목록은 AWS `MissionSummaryResponse`가 `missionId/title/category/reward`만 주기 때문에 앱은 resetCycle, verificationType, status를 기본값으로 채운다. 목록 렌더링은 가능하지만 실제 검수 상태 표현은 제한적이다.
+- Child 미션 제출 후 `AiVerificationResponse`를 앱이 해석하지 않고 성공만 본다. 또한 실 API용 `ApiMissionApprovalListener`는 no-op이라 AI/부모 승인 후 상태 갱신은 push/polling 전까지 화면에 바로 반영되지 않는다.
+
+### Time / Schedule / Policy
+
+- Parent 월 총량은 `POST /api/v1/parents/time-policy`로 실제 저장된다.
+- Child 시간설정은 `weekly-budgets -> templates -> routines` 순서로 저장하며 Swagger schema와 맞다.
+- Backend는 Child 주간 예산 저장 시 해당 월 parent `time-policy`를 요구한다. 즉 부모가 월 총량을 먼저 저장해야 Child 시간설정이 성공한다.
+- Parent 앱의 일별/주별 규칙과 화이트리스트는 AWS 경로가 없어 로컬 저장이다.
+- Backend에는 `GET /api/v1/children/{childId}/policies`가 있고 `blockedApps`를 반환하지만, Parent 앱에서 block app 목록을 쓰는 API가 없다.
+- Child 홈의 blocker는 현재 hardcoded remaining minutes를 사용한다. `PolicyResponse`나 `DailyScheduleResponse`와 연결되지 않아 실 앱 차단 동작은 아직 core feature로 완성되지 않았다.
+
+### Notifications / FCM
+
+- Parent 알림 repository는 AWS 배열 응답을 읽을 수 있다.
+- Child 알림 repository는 아직 `response.data`가 Map이고 `notifications` 배열을 가진다고 가정한다. live AWS는 `ApiResponse.data`가 바로 배열이므로 수정 필요하다.
+- AWS `NotificationResponse`는 `notificationId/title/content/isRead/notificationType/createdAt`만 제공한다. Parent 앱이 기대하는 `payload.childCode`, `payload.missionIndex`도 없고 Child 앱이 선호하는 `deeplink`도 없다.
+- Backend FCM 전송 payload는 `title/body/type/targetId` 중심이다. Child의 `deeplink`, `missionId`, Parent의 `childCode`, `missionIndex` 라우팅 계약과 맞지 않는다.
+- 결과적으로 알림 목록 자체는 Parent에서 보일 수 있지만, 알림을 눌러 정확한 자녀/미션/화면으로 이동하는 상호작용은 아직 불완전하다.
+
+### Report / Usage
+
+- AWS에는 `/reports/weekly` 류의 리포트 endpoint가 없다.
+- Child 앱은 `GET /api/v1/schedules/daily`를 7회 호출해 계획 시간만 합산하고 `actualMinutes=0`으로 보고서를 만든다.
+- 계획표 기반 "껍데기 리포트"는 가능하지만 실제 사용 시간, 초과/미달, AI 제안은 실데이터가 아니다.
+
+### Account / Profile
+
+- 비밀번호 변경과 탈퇴는 `/api/v1/members/password`, `/api/v1/members`로 양 앱 모두 연결되어 있다.
+- 부모/자녀 프로필 조회/수정 API는 Swagger에 없다. Parent 프로필은 로컬 account/session snapshot, Child 프로필은 로컬 session + hardcoded childCode에 의존한다.
+- 자녀 삭제/연결 해제 endpoint도 Swagger에 없다. Parent 앱은 삭제 시 실패 메시지를 반환한다.
+
+## 6. Backend에 요청할 항목
+
+### 배포 필요
+
+1. PR #53 또는 동등 변경 배포
+   - `AuthResponse.childCode`
+   - `ChildrenInfoResponse.childCode`
+   - 기존 자녀 로그인/refresh 시 code가 없으면 생성해서 반환
+
+### API 추가 또는 schema 확장 필요
+
+1. Child code read path
+   - 최소: child login/signup/refresh response에 `childCode`
+   - 권장: `GET /api/v1/members/me` 또는 `GET /api/v1/children/me`로 `memberId/name/email/childCode` 조회
+2. Notification payload 통일
+   - `NotificationResponse`에 `payload` 또는 `deeplink`, `missionId`, `childId` 추가
+   - FCM data payload도 같은 키를 포함
+   - Parent 알림은 `missionIndex`보다 `missionId`를 권장
+3. App block policy write API
+   - Parent가 child별 차단 앱 package list를 저장할 수 있어야 함
+   - 예: `PUT /api/v1/children/{childId}/policies/blocked-apps`
+4. Usage report 또는 actual usage ingestion
+   - 실제 사용량 저장/조회 endpoint 필요
+   - 최소: daily schedule settle과 앱 사용량 수집 경로를 명확히 연결
+5. Parent time-plan rule API
+   - 부모 일별/주별 draft rule이 서버 source of truth여야 하면 endpoint 필요
+   - 아니라면 앱에서 해당 단계는 "로컬 UI 보조"로 명확히 분리
+6. Child unlink/delete mapping
+   - 부모가 연결 해제할 수 있는 endpoint 필요
+7. Profile read/update
+   - 부모/자녀 마이페이지가 서버 값을 보려면 profile endpoint 필요
+
+## 7. Frontend 후속 수정
+
+1. Child 알림 repository를 AWS 배열 응답으로 수정
+   - 현재: `data is Map` + `data['notifications']`
+   - 변경: `data is List`를 우선 처리
+2. Child `AuthToken`/`AuthSession`/`UserProfile`에 `childCode` 저장
+   - PR #53 배포 후 live response에서 읽기
+   - MyPage hardcoded `XY785eZ` 제거
+3. Child 홈 시간/차단 상태를 실데이터로 계산
+   - `GET /api/v1/schedules/daily`
+   - 필요 시 `GET /api/v1/children/{childId}/policies`
+   - `_remainingMinutes` hardcode 제거
+4. Child 미션 제출 응답/상태 갱신 처리
+   - `AiVerificationResponse` 또는 performance status 반영
+   - FCM/polling/SSE 중 하나로 reviewing 이후 상태 갱신
+5. Parent 알림 action routing을 `missionId`/`childId` 중심으로 변경
+   - backend payload가 준비되면 `missionIndex` fallback 제거
+6. Parent home time summary는 로컬 child weekly rules가 아니라 backend policy/schedule에서 계산하도록 재검토
+
+## 8. Demo 관점 권장 순서
+
+1. Backend PR #53 배포
+2. Child 앱 childCode 저장/표시 수정
+3. Child 알림 배열 파싱 수정
+4. 부모 회원가입/로그인 -> 자녀 회원가입 -> 자녀 코드 확인 -> 부모 자녀 등록 E2E 테스트
+5. 부모 월 총량 설정 -> 자녀 주차 예산/요일 템플릿 저장 E2E 테스트
+6. 부모 미션 생성 -> 자녀 미션 목록/상세 -> 사진 제출 -> 부모 승인 E2E 테스트
+7. 앱 차단/리포트/알림 라우팅은 demo에서 설명 범위를 제한하거나 추가 API를 먼저 붙임

--- a/claudedocs/demo-readiness-audit.md
+++ b/claudedocs/demo-readiness-audit.md
@@ -1,0 +1,298 @@
+# QuadS 부스 시연 검수 문서
+
+> 작성일: 2026-06-07  
+> 범위: Parent 앱(`Quad-S-Team12-App-Parent`), Child 앱(`Quad-S-Team12-App-Child`), 백엔드(`2026-Bridge-quadS`)  
+> 기준: 실출시 품질이 아니라 부스에서 "시간 설정", "앱 차단", "미션" 흐름을 안정적으로 보여줄 수 있는지 검수
+
+---
+
+## 1. 결론
+
+### Mock 앱 시연
+
+현재 상태로는 **양 앱 모두 mock 모드 시연은 가능**하다.
+
+- Parent/Child 앱의 dev 환경은 `useMocks: true`라서 기본 실행 시 실백엔드를 호출하지 않는다.
+- 두 앱 모두 `flutter analyze`와 `flutter test`가 통과했다.
+- 화면 이동, mock 미션, mock 시간 설정 화면은 데모용으로 안정적인 편이다.
+
+다만 **앱 차단은 mock 화면만으로는 자동 시연되지 않는다.** Child 앱에 Android 접근성 서비스 기반 차단 구현은 있지만, 현재 홈 화면의 남은 시간이 하드코딩 `120분`이라 자동 차단 조건(`remainingMinutes <= 0`)에 들어가지 않는다.
+
+### 실백엔드 연동 시연
+
+현재 코드 그대로 `useMocks: false`로 전환하면 **핵심 흐름이 일부 막힌다.**
+
+가장 중요한 차단점은 아래 5개다.
+
+1. Parent 로그인 응답에 `memberId`가 없어 Parent 홈이 실데이터를 로드하지 못한다.
+2. Parent의 자녀 등록 요청과 백엔드 계약이 다르다. 앱은 `childrenBirth`를 보내지 않고 생성된 자녀 객체를 기대하지만, 백엔드는 `childrenBirth`를 필수로 받고 `Void`를 반환한다.
+3. Child 미션 목록 조회가 막힌다. Child 앱은 `GET /api/v1/missions`를 호출하지만, 백엔드는 Parent 권한과 `childId` query를 요구한다.
+4. Child 미션 제출이 막힌다. 앱은 multipart `image`만 보내지만, 백엔드는 `childId`, `category`, `prompt`도 필수로 요구한다.
+5. 앱 차단/화이트리스트는 앱-백엔드 모델이 연결되어 있지 않다. Parent 앱은 whitelist 저장 API를 호출하지만 백엔드에는 해당 쓰기 API가 없고, Child 앱 차단 서비스는 백엔드 `blockedApps`를 사용하지 않는다.
+
+따라서 **빠른 부스 시연 목표라면 mock 모드 중심으로 시연하고, 앱 차단만 별도 데모 브랜치/수동 토글로 준비하는 것을 권장**한다. 실백엔드까지 붙여 보여주려면 아래 "최소 조치"가 필요하다.
+
+---
+
+## 2. 실행 검증 결과
+
+| 대상 | 명령 | 결과 |
+|---|---|---|
+| Parent 앱 | `flutter analyze && flutter test` | 통과 |
+| Child 앱 | `flutter analyze && flutter test` | 통과 |
+| 백엔드 | `bash ./gradlew test` | 실패. 코드 실패가 아니라 로컬 JDK 21 미설치로 Gradle toolchain 해석 실패 |
+
+백엔드 테스트 실패 사유:
+
+- `build.gradle`은 Java toolchain 21을 요구한다.
+- 현재 로컬 `java -version`은 OpenJDK 17이다.
+- Gradle 메시지: `Cannot find a Java installation ... matching: {languageVersion=21}`.
+
+백엔드 테스트를 실제로 돌리려면 JDK 21 설치와 `gradlew` 실행 권한 정리가 필요하다.
+
+---
+
+## 3. Parent 앱 검수
+
+### 인증/세션
+
+- 앱은 `/auth/parent/login`, `/auth/parent/signup`, `/auth/token/refresh`로 백엔드 경로에 맞춰져 있다.
+- 응답 래퍼 `{isSuccess, code, message, data}` 언래핑도 Dio 인터셉터에 반영되어 있다.
+- 하지만 백엔드 `AuthResponse`는 현재 `accessToken`, `refreshToken`만 반환한다.
+- Parent 앱은 로그인 성공 후 `data.parentId`를 `AuthSession.current_parent_id`에 저장하고, 홈에서 이 값이 비어 있으면 자녀/미션 로딩을 하지 않는다.
+
+실백엔드 시연 영향: **Parent 로그인 후 홈이 빈 상태로 보일 가능성이 높다.**
+
+필요 조치:
+
+- 백엔드 `MemberResDTO.AuthResponse`에 `memberId`, 가능하면 `name/email`도 추가.
+- `AuthService.issueTokens()`에서 인증된 `Parent/Children` 엔티티의 ID를 응답에 담기.
+
+### 자녀 등록
+
+앱 현재 요청:
+
+- `POST /api/v1/parents/children`
+- body: `{childrenName, childrenCode, profileImageKey?}`
+- `childrenBirth` 생략
+- 응답: 생성된 `ChildSummary` 객체 기대
+
+백엔드 현재 계약:
+
+- `RegisterChildRequest.childrenBirth`가 `@NotBlank` 필수
+- `profileImageUrl` 필드만 받음
+- `ParentController.registerChild()`는 `ApiResponse<Void>` 반환
+
+실백엔드 시연 영향: **Parent 앱에서 자녀 등록이 실패하거나 응답 파싱이 실패한다.**
+
+필요 조치:
+
+- `childrenBirth` optional로 완화.
+- 등록 응답을 `ChildrenInfoResponse`로 반환.
+- `profileImageKey`를 받거나, 데모에서는 사진 업로드를 생략하고 `profileImageUrl/profileImageKey`를 모두 optional로 처리.
+- 참고: Parent 앱은 `/api/v1/files/photos` 업로드를 best-effort로 호출하지만 백엔드에는 현재 파일 업로드 컨트롤러가 없다. 실패해도 무사진 등록으로 진행되도록 앱은 방어되어 있다.
+
+### 시간 설정
+
+Parent 앱의 월 총량 저장은 백엔드와 비교적 잘 맞는다.
+
+- 앱: `POST /api/v1/parents/time-policy`
+- 백엔드: `POST /api/v1/parents/time-policy`
+- body: `{childId, yearMonth, baseTime}`
+
+주의점:
+
+- Parent 홈 세션 `parentId`가 비면 시간 설정 플로우 진입/저장에 필요한 선택 자녀가 제대로 잡히지 않는다.
+- 일별/주별 시간 규칙은 앱이 로컬 저장만 한다. 백엔드로 보내지 않는다.
+- whitelist 저장은 `/children/{childrenId}/time-plan/whitelist`를 호출하지만 백엔드에 없다.
+
+실백엔드 시연 영향:
+
+- "월 총 사용시간 설정"은 `memberId`와 자녀 등록 문제가 해결되면 가능하다.
+- "앱 허용/차단 리스트 저장"은 현재 실백엔드로는 불가하다.
+
+### 미션
+
+동작 가능한 부분:
+
+- 미션 생성: 앱 `POST /api/v1/missions`와 백엔드 생성 API가 맞다.
+- 미션 목록: Parent 앱은 `GET /api/v1/missions?childId=...`를 호출하고 백엔드도 같은 형태다.
+- 승인/거절: 앱이 `missionId -> performanceId` 라운드트립 후 `PATCH /api/v1/missions/performances/{performanceId}/approve|reject`를 호출하므로 백엔드와 맞다.
+
+막히는 부분:
+
+- 미션 수정/삭제/일괄 저장은 앱에 호출 코드가 있지만 백엔드 API가 없다.
+
+부스 기준:
+
+- 미션 "생성 -> 자녀 제출 -> 부모 승인/거절"만 보여주면 충분하다.
+- 수정/삭제는 시연에서 빼는 것이 안전하다.
+
+---
+
+## 4. Child 앱 검수
+
+### 인증/가입
+
+- 로그인은 앱의 `username`을 백엔드 `email`로 보내도록 맞춰져 있다.
+- 그래서 시연 계정의 아이디 칸에는 이메일 형식 값을 넣어야 한다.
+- 회원가입은 앱이 `{email: username, password}`만 보내는데 백엔드 `SignUpRequest`는 `name`, `email`, `password`를 필수로 요구한다.
+
+실백엔드 시연 영향:
+
+- 로그인은 사전 생성된 자녀 계정이 있으면 가능하다.
+- Child 앱 회원가입 화면으로 실백엔드 계정을 만드는 것은 현재 어렵다.
+- 자녀 코드도 signup 응답에 반환되지 않아서 Parent 연결 시연에는 DB seed 또는 백엔드 응답 추가가 필요하다.
+
+### 시간 설정
+
+Child 앱은 저장 시 백엔드의 3개 API로 분할 호출한다.
+
+1. `POST /api/v1/schedules/weekly-budgets`
+2. `PUT /api/v1/schedules/templates`
+3. `GET/DELETE/POST /api/v1/schedules/routines`
+
+백엔드도 이 API들을 제공하고, 모두 Child JWT의 `asChildren()`로 childId를 식별한다.
+
+주의점:
+
+- 저장 전에 Parent가 같은 `yearMonth`로 `time-policy.baseTime`을 먼저 설정해야 한다.
+- Child 앱의 `allowedHours`는 "사용 가능 시간 격자"에 가깝지만, 백엔드 `routines`는 "학원/고정 일정" 의미다. 현재 앱 코드는 allowedHours를 routine으로 저장한다.
+- `GET /time-setup/previous-week`, `GET /time-setup/current`는 아직 백엔드에 없다. v2/현재 스케줄 조회 실데이터는 막힌다.
+
+부스 기준:
+
+- mock 시연은 안정적.
+- 실백엔드 저장 시연은 Parent 월 총량 선설정과 Child 계정/토큰이 준비되어야 한다.
+- 의미 충돌 때문에 "정확한 시간 정책"보다는 "설정값 저장 API 호출 데모" 수준으로 보는 것이 맞다.
+
+### 앱 차단
+
+구현된 것:
+
+- Android `AccessibilityService`가 foreground package를 감시한다.
+- blocking flag가 true면 자기 앱, 시스템 UI, 설정, 기본 전화, 기본 SMS, 홈 런처 외 앱을 HOME으로 튕긴다.
+- Flutter `DeviceBlockController.applyForRemainingMinutes()`가 남은 시간이 0 이하일 때 차단을 켠다.
+
+현재 막히는 것:
+
+- Child 홈의 남은 시간은 `90 + 30`으로 하드코딩되어 있어 차단이 자동으로 켜지지 않는다.
+- 백엔드 `GET /api/v1/children/{childId}/policies`는 `blockedApps`를 반환하지만 Child 앱이 이 값을 읽어 접근성 allow/block 목록에 반영하지 않는다.
+- Parent 앱 whitelist와 백엔드 `AppBlock`은 연결되어 있지 않다. AppBlock 쓰기 API도 없다.
+
+부스 기준 권장:
+
+- Android 실기기에서 접근성 권한을 미리 켜둔다.
+- 데모용으로 남은 시간을 0으로 만드는 별도 빌드/토글을 준비하면 앱 차단은 보여줄 수 있다.
+- 백엔드 기반 패키지별 차단까지 보여주는 것은 현재 범위를 넘는다.
+
+### 미션
+
+현재 Child 앱 호출:
+
+- 목록: `GET /api/v1/missions`
+- 상세: `GET /api/v1/missions/{id}`
+- 제출: `POST /api/v1/missions/{id}/performances` multipart `image` 1개
+
+백엔드 현재 계약:
+
+- 목록은 `childId` query와 Parent 권한을 요구한다.
+- 제출은 `childId`, `image`, `category`, `prompt`를 모두 `@RequestParam`으로 요구한다.
+
+실백엔드 시연 영향:
+
+- Child 미션 목록 조회가 실패한다.
+- Child 미션 사진 제출도 앱 요청만으로는 실패한다.
+
+필요 조치:
+
+- `GET /api/v1/missions`에서 CHILDREN 권한이면 JWT의 childId로 본인 미션을 반환하도록 분기.
+- `POST /api/v1/missions/{missionId}/performances`에서 childId는 JWT에서, category/prompt는 mission setting 또는 `MissionPromptProvider`에서 파생하도록 변경.
+
+---
+
+## 5. 백엔드 정합성 검수
+
+### 현재 제공 중인 핵심 API
+
+- Auth: `/auth/parent/login`, `/auth/children/login`, signup, refresh, logout
+- Parent: `/api/v1/parents/children`, `/api/v1/parents/time-policy`
+- Child policy read: `/api/v1/children/{childId}/policies`
+- Mission: create/list/detail/performances/approve/reject
+- Schedule: daily/extend/settle/templates/routines/weekly-budgets
+- Notification/FCM: 기본 API 존재
+
+### 데모를 막는 계약 차이
+
+| 영역 | 차이 | 영향 |
+|---|---|---|
+| Auth | `AuthResponse`에 `memberId` 없음 | Parent 홈 실데이터 로드 막힘 |
+| Child 연결 | `childrenBirth` 필수, 응답 `Void` | Parent 자녀 등록 실패/파싱 실패 |
+| Child signup | 백엔드는 `name/email/password`, 앱은 `username/password` | Child 앱 회원가입 실통신 실패 |
+| Mission list | 백엔드는 Parent + `childId`, Child 앱은 Child 토큰으로 no-query 호출 | Child 미션 홈 실패 |
+| Mission submit | 백엔드는 `childId/category/prompt/image`, 앱은 `image`만 | Child 미션 제출 실패 |
+| App block | 백엔드 AppBlock 쓰기 API 없음, 앱 native blocker와 미연결 | 실백엔드 기반 앱 차단 불가 |
+| Time confirm | `/time-confirm/*` 없음 | Child 시간 확인/수정요청 실데이터 불가 |
+
+---
+
+## 6. 부스 시연 권장 플랜
+
+### 가장 안전한 플랜: Mock 중심
+
+1. Parent/Child 앱 모두 dev 기본값 `useMocks: true` 유지.
+2. Parent 앱에서 mock 자녀/시간 설정/미션 생성 화면을 시연.
+3. Child 앱에서 mock 시간 설정, mock 미션 수행 흐름을 시연.
+4. 앱 차단은 Android 실기기 접근성 권한을 미리 켜고, 별도 데모용으로 남은 시간 0 상태를 만드는 빌드/토글을 준비.
+
+장점:
+
+- 현재 테스트 통과 상태 그대로 시연 가능.
+- 백엔드 계정/DB seed/토큰 문제를 피할 수 있다.
+
+주의:
+
+- "실제 백엔드 저장됨"을 보여주기는 어렵다.
+- 앱 차단은 현재 기본 앱 상태에서는 자동 발동하지 않는다.
+
+### 실백엔드까지 보여주는 최소 플랜
+
+아래 순서대로만 고치면 "Parent 시간 설정 -> Child 시간 저장 -> Parent 미션 생성 -> Child 제출 -> Parent 승인" 흐름이 열린다.
+
+1. 로컬 백엔드 실행 환경 정리
+   - JDK 21 설치
+   - `gradlew` 실행 권한 부여 또는 `bash ./gradlew ...` 사용
+   - PostgreSQL/local env 또는 test profile 정리
+
+2. Auth 응답 보강
+   - `AuthResponse(memberId, name/email)` 추가
+   - Parent 홈 로딩의 전제 조건 해결
+
+3. 자녀 연결 보강
+   - `childrenBirth` optional
+   - `POST /api/v1/parents/children`이 생성된 자녀 객체 반환
+   - 자녀 코드 확인을 위해 Child signup 응답 또는 profile/me 응답에 `childCode` 포함
+
+4. Child 미션 API 보강
+   - Child 토큰으로 `GET /api/v1/missions` 가능하게 변경
+   - performance 제출은 image만 받아도 동작하도록 서버에서 child/category/prompt 파생
+
+5. 앱 차단 데모 보강
+   - 빠른 데모용: Child 앱에 "남은 시간 0분" 디버그 토글 또는 빌드 플래그 추가
+   - 실정합성용: Parent가 설정한 blocked/whitelist를 백엔드에 저장하고 Child가 policy를 읽어 native blocker에 반영
+
+---
+
+## 7. 최종 판정
+
+| 항목 | Mock 시연 | 실백엔드 시연 | 메모 |
+|---|---:|---:|---|
+| Parent 시간 설정 화면 | 가능 | 부분 가능 | 월 총량 API는 맞음. whitelist는 백엔드 없음 |
+| Child 시간 설정 화면 | 가능 | 부분 가능 | 저장 API는 분할 호출 가능. 조회/확인 플로우는 없음 |
+| 앱 차단 | 별도 준비 필요 | 불가에 가까움 | native 구현은 있으나 남은 시간/blockedApps와 미연결 |
+| Parent 미션 생성 | 가능 | 가능 | 자녀 연결/세션이 먼저 필요 |
+| Child 미션 목록 | 가능 | 불가 | 백엔드 권한/파라미터 구조 변경 필요 |
+| Child 미션 제출 | 가능 | 불가 | 백엔드가 image 외 파라미터를 요구 |
+| Parent 미션 승인/거절 | 가능 | 부분 가능 | performance가 생성되어 있어야 함 |
+
+**한 줄 정리:** 부스용으로는 mock 시연은 충분히 가능하다. 실백엔드까지 붙여서 보여주려면 Auth/memberId, 자녀 연결, Child 미션 조회/제출, 앱 차단 트리거를 먼저 손봐야 한다.

--- a/src/main/java/me/sogom/bridge/domain/member/service/ParentService.java
+++ b/src/main/java/me/sogom/bridge/domain/member/service/ParentService.java
@@ -180,6 +180,7 @@ public class ParentService {
                     .basePolicyMinutes(0)
                     .todaySchedule(null)
                     .rewardPoolMinutes(0)
+                    .totalAvailableTime(0)
                     .build();
         }
 
@@ -194,6 +195,7 @@ public class ParentService {
                     .basePolicyMinutes(activePolicy.getBaseTime())
                     .todaySchedule(null)
                     .rewardPoolMinutes(activePolicy.getAccumulatedRewardTime())
+                    .totalAvailableTime(activePolicy.getTotalAvailableTime())
                     .build();
         }
 
@@ -208,6 +210,7 @@ public class ParentService {
                 .basePolicyMinutes(basePolicyMinutes)
                 .todaySchedule(dailySchedule.orElse(null))
                 .rewardPoolMinutes(activePolicy.getAccumulatedRewardTime())
+                .totalAvailableTime(activePolicy.getTotalAvailableTime())
                 .build();
     }
 

--- a/src/main/java/me/sogom/bridge/domain/schedule/dto/TimeSummaryResponse.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/dto/TimeSummaryResponse.java
@@ -13,4 +13,5 @@ public class TimeSummaryResponse {
     private int basePolicyMinutes;
     private DailyScheduleResponse todaySchedule;
     private int rewardPoolMinutes;
+    private int totalAvailableTime;
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
@@ -66,8 +66,10 @@ public class ScheduleService {
                     TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
                             .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책이 설정되지 않았습니다."));
 
-                    // 템플릿에 설정된 시간만큼 기본 시간에서 선차감 진행
-                    policy.deductAvailableTime(template.getBaseMinutes());
+                    int baseMinutes = resolveDailyBaseMinutes(policy, template.getBaseMinutes());
+                    if (baseMinutes > 0) {
+                        policy.deductAvailableTime(baseMinutes);
+                    }
                     timePolicyRepository.save(policy);
 
                     // 자녀 엔티티 조회
@@ -77,7 +79,7 @@ public class ScheduleService {
                     DailyTimeAllocation newAllocation = DailyTimeAllocation.builder()
                             .child(child)
                             .targetDate(targetDate)
-                            .baseMinutes(template.getBaseMinutes())
+                            .baseMinutes(baseMinutes)
                             .extendedMinutes(0) // 처음 생성될 때는 연장 시간이 0분
                             .build();
 
@@ -178,10 +180,17 @@ public class ScheduleService {
         String yearMonth = yearMonthOf(targetDate);
         int weekNumber = weekNumberOf(targetDate);
         DayOfWeek dayOfWeek = targetDate.getDayOfWeek();
+        Optional<TimePolicy> policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth);
 
         return weeklyRepository.findByChildIdAndDayOfWeekAndYearMonthAndWeekNumber(
                         childId, dayOfWeek, yearMonth, weekNumber)
-                .map(template -> DailyScheduleResponse.preview(targetDate, template.getBaseMinutes(), 0));
+                .map(template -> DailyScheduleResponse.preview(
+                        targetDate,
+                        policy
+                                .map(timePolicy -> resolveDailyBaseMinutes(timePolicy, template.getBaseMinutes()))
+                                .orElse(template.getBaseMinutes()),
+                        0
+                ));
     }
 
     public String yearMonthOf(LocalDate targetDate) {
@@ -190,6 +199,11 @@ public class ScheduleService {
 
     public int weekNumberOf(LocalDate targetDate) {
         return Math.min(((targetDate.getDayOfMonth() - 1) / 7) + 1, 4);
+    }
+
+    private int resolveDailyBaseMinutes(TimePolicy policy, int requestedMinutes) {
+        int safeRequestedMinutes = Math.max(requestedMinutes, 0);
+        return Math.min(safeRequestedMinutes, policy.getTotalAvailableTime());
     }
 
     //자녀가 여분(보상) 시간을 사용해 오늘 시간을 연장할 때
@@ -205,15 +219,15 @@ public class ScheduleService {
         //날짜 변환 ("yyyy-MM" 형태)
         String yearMonth = targetDate.format(DateTimeFormatter.ofPattern("yyyy-MM"));
 
-        //DB에서 이번 달 부모 정책 정보 가져오기
+        //오늘의 스케줄 데이터를 먼저 가져오기
+        //아직 daily가 없다면 템플릿 시간 중 현재 사용 가능한 만큼만 생성된다.
+        DailyTimeAllocation allocation = getOrCreateDailyAllocation(childId, targetDate);
+
         TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
                 .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책이 설정되지 않았습니다."));
 
         // 기본 시간에서 먼저 차감하고, 부족한 경우 보상 시간에서 차감한다.
         policy.deductAvailableTime(extraMinutes);
-
-        //오늘의 스케줄 데이터를 가져오기
-        DailyTimeAllocation allocation = getOrCreateDailyAllocation(childId, targetDate);
 
         //오늘 스케줄에 시간을 연장하기
         allocation.addExtraTime(extraMinutes);


### PR DESCRIPTION
## 변경 사항
- `/api/v1/schedules/daily`에서 오늘 daily 엔티티가 없을 때, 템플릿 시간이 현재 월간 사용 가능 시간보다 커도 예외 대신 `min(템플릿 시간, totalAvailableTime)` 만큼 `baseMinutes`를 생성하도록 변경했습니다.
- 현재 월간 사용 가능 시간이 0분이면 차감 없이 `baseMinutes=0`, `extendedMinutes=0`인 daily 엔티티를 생성합니다.
- 부모 홈 시간 요약 응답에 `totalAvailableTime`을 추가해 `baseTime + accumulatedRewardTime` 값을 앱에서 그대로 사용할 수 있게 했습니다.
- 부모 홈에서 사용하는 daily preview도 실제 생성 가능한 `baseMinutes` 기준으로 내려가도록 맞췄습니다.
- `/api/v1/schedules/extend`는 별도 daily API를 호출하지 않고, 서비스 내부에서 오늘 daily 엔티티를 조회/생성한 뒤 요청한 `extraMinutes`만 월간 사용 가능 시간에서 차감해 `extendedMinutes`에 누적하도록 처리 순서를 정리했습니다.

## 배경
자녀앱에서 오늘의 시간이 소진된 뒤 월간 남은시간을 오늘 시간으로 가져오려면, 오늘 daily 엔티티가 0분이라도 존재해야 이후 extend/settle 플로우가 이어집니다. 또한 부모앱은 `rewardPoolMinutes`만으로는 월간 남은시간을 정확히 표시할 수 없어 `totalAvailableTime`이 필요합니다.

## 참고
- `extend`는 기존 백엔드 정책대로 `baseTime`을 먼저 차감하고, 부족한 부분만 `accumulatedRewardTime`에서 차감합니다.
- 이번 변경은 앱에서 `/daily`를 추가 호출하게 만드는 변경이 아니라, 백엔드 서비스 내부의 daily 엔티티 조회/생성 순서를 안정화하는 변경입니다.

## 검증
- `git diff --check` 통과
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home bash ./gradlew compileJava` 통과