### PR TITLE
Fix: 다른 주차 시간을 감안해서 남는 시간만 가져오도록 수정

### DIFF
--- a/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
+++ b/src/main/java/me/sogom/bridge/domain/policy/entity/TimePolicy.java
@@ -75,4 +75,15 @@ public class TimePolicy extends BaseEntity {
         }
         this.accumulatedRewardTime += unusedMinutes;
     }
+
+    // 미래 일별 예산을 보호하기 위해, 오직 순수 보상(보너스) 풀에서만 깎아내는 전용 메서드
+    public void deductRewardTime(int minutes) {
+        if (minutes <= 0) {
+            throw new IllegalArgumentException("차감할 시간은 0보다 커야 합니다.");
+        }
+        if (this.accumulatedRewardTime < minutes) {
+            throw new IllegalArgumentException("사용 가능한 보상(보너스 및 여분) 시간이 부족합니다.");
+        }
+        this.accumulatedRewardTime -= minutes;
+    }
 }

--- a/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/me/sogom/bridge/domain/schedule/service/ScheduleService.java
@@ -108,6 +108,7 @@ public class ScheduleService {
             return false;
         }
 
+        // 템플릿(요일별) 배분은 주간 예산과 100% 완벽 일치(==) 검증
         boolean weeklyTemplatesMatchBudgets = budgets.stream()
                 .filter(budget -> requiredWeeks.contains(budget.getWeekNumber()))
                 .allMatch(budget ->
@@ -145,10 +146,27 @@ public class ScheduleService {
         ));
     }
 
+    // 시간 설정 전체 확정 시점에 여분 정산 처리 로직 추가
     @Transactional
     public void completeTimePlan(Long childId, String yearMonth) {
         if (!hasChildPlan(childId, yearMonth)) {
             throw new IllegalArgumentException("시간 계획이 아직 완료되지 않았습니다.");
+        }
+
+        // 월간 예산 분배 시 남은 자투리 여분을 계산해 보상 풀로 자동 정산
+        TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
+                .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책이 설정되지 않았습니다."));
+
+        List<WeeklyBudget> budgets = weeklyBudgetRepository.findAllByChildIdAndYearMonth(childId, yearMonth);
+        int totalAllocatedMinutes = budgets.stream()
+                .mapToInt(WeeklyBudget::getAllocatedMinutes)
+                .sum();
+
+        int remainderMinutes = policy.getBaseTime() - totalAllocatedMinutes;
+        if (remainderMinutes > 0) {
+            policy.updateBaseTime(totalAllocatedMinutes); // baseTime은 요일 템플릿과 매핑되도록 정액 축소
+            policy.addReward(remainderMinutes);           // 남은 여분 분(minutes)은 보상 시간 저금통으로 전액 격리 이동
+            timePolicyRepository.save(policy);
         }
 
         Children child = childrenRepository.findById(childId).orElseThrow();
@@ -226,8 +244,8 @@ public class ScheduleService {
         TimePolicy policy = timePolicyRepository.findByChildIdAndYearMonth(childId, yearMonth)
                 .orElseThrow(() -> new IllegalArgumentException("해당 월의 부모 정책이 설정되지 않았습니다."));
 
-        // 기본 시간에서 먼저 차감하고, 부족한 경우 보상 시간에서 차감한다.
-        policy.deductAvailableTime(extraMinutes);
+        // 미래 예산을 무단으로 탕진하지 않도록 오직 격리된 보상 시간 풀에서만 차감!
+        policy.deductRewardTime(extraMinutes);
 
         //오늘 스케줄에 시간을 연장하기
         allocation.addExtraTime(extraMinutes);


### PR DESCRIPTION
## 설명
기존 코드는 basetime에서 차감하도록 하여 추가적인 제한이 없을 시 전체 월간 시간을 차감할 수도 있음

## 변경사항
월간 예산 분배 시 남은 자투리 여분을 계산하여 남은 시간 + 보너스 시간에서만 차감할 수 있도록 함

## 관련 이슈
- Closes https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/59
- Relates to https://github.com/2026-quadS-Bridge-Project/2026-Bridge-quadS/issues/59